### PR TITLE
Update v1.3.17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,23 @@
 
 # Changelog
 
+## [1.3.17] - 2026-05-07
+
+### Added
+- **Scan Optimization (Issue #34)**: Replaced the monolithic up-front zip scan with a three-phase pipeline:
+  - **Light Pass**: Filesystem walk only — package cards appear as animated skeletons within seconds of opening a library. No `.var` files are opened in this phase.
+  - **Hard Pass**: Prioritized zip scan — packages on the current page are always processed first. Navigating to a new page or clicking an unscanned card immediately reprioritizes that work in the queue. Thumbnails appear as each package finishes.
+  - **Link Pass**: Dependency resolution, duplicate detection, and orphan analysis run after all packages are scanned. Results (missing deps, obsolete, duplicate flags) are streamed back per-package via a `package:analyzed` event.
+- **Thumbnail Cache**: Package cover images are now cached to `%AppData%/YAVAM/thumbnails/`. On subsequent library opens, thumbnails are served from cache, completely skipping the zip open for that step. Cache keys include file modification time and size, so updated packages invalidate automatically.
+- **Stacked Progress Bar**: The existing single progress bar is replaced with three stacked strips — one per scan phase (blue = Discovering, amber = Scanning, green = Analysing). Each strip shows its own package count and fills independently.
+- **Settings — Thumbnail Cache**: New "Thumbnail Cache" section in Application settings shows current cache size and provides a "Clear Cache" button.
+- **Extensible `DependencyResolver` interface** (`pkg/services/library/dependency_resolver.go`): The Link Pass accepts a slice of resolvers tried in order. `LocalResolver` (current library) is the default. Future `MultiLibraryResolver` and `OnlineResolver` implementations can be plugged in without changing the scan orchestrator.
+
+### Changed
+- **Search Bar**: Search no longer filters in real-time while typing. Results are applied on Enter (desktop) or the search button (mobile). This prevents the package grid from jumping mid-scan as the user types. Escape clears the search.
+- **Backend Analysis**: Dependency/duplicate/orphan analysis (`analyzePackages`) moved from the frontend to the Go backend (`LinkPass` in `pkg/services/library/analysis.go`). The frontend now listens for `package:analyzed` events instead of running a full graph traversal in the browser.
+- **Scan Events**: New `package:discovered` (Light Pass) and `package:analyzed` (Link Pass) events join the existing `package:scanned`. The `scan:progress` event is replaced by `scan:stage` which carries the active phase name, current count, total, and done flag.
+
 ## [1.3.16] - 2026-04-29
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ I personally have a dying hard drive with thousands of files, it's VERY slow and
 - **Privacy Settings**: Resolved a race condition where privacy mode and blur settings were not applying properly upon application launch.
 - **Network Settings**: Improved server initialization logic. The "Start Server" button now correctly triggers the server process independently instead of incorrectly manipulating the "Run on Startup" preference toggle.
 ### Added
-- **Scan Optimization (Issue [#34](https://github.com/FivelSystems/YAVAM/issues/34))**: Replaced the monolithic up-front zip scan with a three-phase pipeline:
+- **Scan Optimization (Issue #34)**: Replaced the monolithic up-front zip scan with a three-phase pipeline:
   - **Light Pass**: Filesystem walk only — package cards appear as animated skeletons within seconds of opening a library. No `.var` files are opened in this phase.
   - **Hard Pass**: Prioritized zip scan — packages on the current page are always processed first. Navigating to a new page or clicking an unscanned card immediately reprioritizes that work in the queue. Thumbnails appear as each package finishes.
   - **Link Pass**: Dependency resolution, duplicate detection, and orphan analysis run after all packages are scanned. Results (missing deps, obsolete, duplicate flags) are streamed back per-package via a `package:analyzed` event.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 # Changelog
 
-## [1.3.17] - 2026-05-07
+## [1.3.17] - 2026-05-08
 This update aims to be friendlier towards slow hard drives by splitting the scan into 3 distinct phases, improving the initial loading time and allowing the user to interact with the application while the scan is in progress.
 
 I personally have a dying hard drive with thousands of files, it's VERY slow and having to wait for a full scan to complete before being able to do anything is a pain. 
@@ -14,6 +14,8 @@ I personally have a dying hard drive with thousands of files, it's VERY slow and
 ### Fixed
 - **Library Switching**: Clean stop between library selections now works properly even in web clients.
 - **Library Switching**: Packages from previous libraries will no longer appear after switching libraries from an unfinished scan process.
+- **Privacy Settings**: Resolved a race condition where privacy mode and blur settings were not applying properly upon application launch.
+- **Network Settings**: Improved server initialization logic. The "Start Server" button now correctly triggers the server process independently instead of incorrectly manipulating the "Run on Startup" preference toggle.
 ### Added
 - **Scan Optimization (Issue [#34](https://github.com/FivelSystems/YAVAM/issues/34))**: Replaced the monolithic up-front zip scan with a three-phase pipeline:
   - **Light Pass**: Filesystem walk only — package cards appear as animated skeletons within seconds of opening a library. No `.var` files are opened in this phase.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,15 @@
 # Changelog
 
 ## [1.3.17] - 2026-05-07
+This update aims to be friendlier towards slow hard drives by splitting the scan into 3 distinct phases, improving the initial loading time and allowing the user to interact with the application while the scan is in progress.
 
+I personally have a dying hard drive with thousands of files, it's VERY slow and having to wait for a full scan to complete before being able to do anything is a pain. 
+
+### Fixed
+- **Library Switching**: Clean stop between library selections now works properly even in web clients.
+- **Library Switching**: Packages from previous libraries will no longer appear after switching libraries from an unfinished scan process.
 ### Added
-- **Scan Optimization (Issue #34)**: Replaced the monolithic up-front zip scan with a three-phase pipeline:
+- **Scan Optimization (Issue [#34](https://github.com/FivelSystems/YAVAM/issues/34))**: Replaced the monolithic up-front zip scan with a three-phase pipeline:
   - **Light Pass**: Filesystem walk only — package cards appear as animated skeletons within seconds of opening a library. No `.var` files are opened in this phase.
   - **Hard Pass**: Prioritized zip scan — packages on the current page are always processed first. Navigating to a new page or clicking an unscanned card immediately reprioritizes that work in the queue. Thumbnails appear as each package finishes.
   - **Link Pass**: Dependency resolution, duplicate detection, and orphan analysis run after all packages are scanned. Results (missing deps, obsolete, duplicate flags) are streamed back per-package via a `package:analyzed` event.

--- a/app.go
+++ b/app.go
@@ -15,6 +15,7 @@ import (
 	"yavam/pkg/models"
 	"yavam/pkg/services/auth"
 	"yavam/pkg/services/config"
+	"yavam/pkg/services/library"
 	"yavam/pkg/updater"
 	"yavam/pkg/utils"
 
@@ -277,18 +278,38 @@ func (a *App) CancelScan() {
 	a.scanWg.Wait()
 }
 
+// SetCurrentPage tells the Hard Pass to prioritise the packages on the user's current page.
+// Call this on every page navigation with the file paths currently visible on screen.
+func (a *App) SetCurrentPage(paths []string) {
+	a.manager.SetCurrentPage(paths)
+}
+
+// PrioritizePackage bumps a single package to the front of the Hard Pass queue.
+// Call this when the user clicks a package card before it has finished scanning.
+func (a *App) PrioritizePackage(path string) {
+	a.manager.Prioritize([]string{path})
+}
+
+// ClearThumbnailCache deletes all cached package cover images.
+func (a *App) ClearThumbnailCache() error {
+	return a.manager.ClearThumbnailCache()
+}
+
+// GetThumbnailCacheSize returns the total size of the thumbnail cache in bytes.
+func (a *App) GetThumbnailCacheSize() (int64, error) {
+	return a.manager.ThumbnailCacheSize()
+}
+
 // ScanPackages triggers the scan process
 func (a *App) ScanPackages(vamPath string) error {
 	if vamPath == "" || vamPath == "." {
-		// Nothing to scan
 		return nil
 	}
 
-	// Cancel previous scan and wait
+	// Cancel any previous scan and wait for it to finish.
 	a.CancelScan()
 
 	a.scanMu.Lock()
-	// Create new context wrapped around app context
 	ctx, cancel := context.WithCancel(a.ctx)
 	a.scanCancel = cancel
 	a.scanMu.Unlock()
@@ -298,17 +319,32 @@ func (a *App) ScanPackages(vamPath string) error {
 		defer a.scanWg.Done()
 		defer cancel()
 
-		err := a.manager.ScanAndAnalyze(ctx, vamPath, func(pkg models.VarPackage) {
-			runtime.EventsEmit(a.ctx, "package:scanned", pkg)
-		}, func(current, total int) {
-			runtime.EventsEmit(a.ctx, "scan:progress", map[string]int{"current": current, "total": total})
-		})
+		err := a.manager.ScanFull(
+			ctx,
+			vamPath,
+			// Phase 1 — Light Pass: file discovered, no zip open yet
+			func(pkg models.VarPackage) {
+				runtime.EventsEmit(a.ctx, "package:discovered", pkg)
+			},
+			// Phase 2 — Hard Pass: full metadata (no thumbnail bytes — lazy-loaded from cache)
+			func(pkg models.VarPackage) {
+				runtime.EventsEmit(a.ctx, "package:scanned", pkg)
+			},
+			// Phase 3 — Link Pass: ALL analysis results in ONE batch event.
+			// This replaces N individual "package:analyzed" events which caused
+			// N × O(N) React state updates (O(N²) total) → freeze on large libraries.
+			func(analyses []library.PackageAnalysis) {
+				runtime.EventsEmit(a.ctx, "scan:analysis:complete", analyses)
+			},
+			// Stage progress: emitted across all three phases
+			func(sp library.ScanStageProgress) {
+				runtime.EventsEmit(a.ctx, "scan:stage", sp)
+			},
+		)
 
-		if err != nil {
-			if err != context.Canceled {
-				runtime.EventsEmit(a.ctx, "scan:error", err.Error())
-			}
-		} else {
+		if err != nil && err != context.Canceled {
+			runtime.EventsEmit(a.ctx, "scan:error", err.Error())
+		} else if err == nil {
 			runtime.EventsEmit(a.ctx, "scan:complete", true)
 		}
 	}()

--- a/frontend/src/components/common/ScanProgressBar.tsx
+++ b/frontend/src/components/common/ScanProgressBar.tsx
@@ -9,9 +9,9 @@ interface ScanProgressBarProps {
 const PHASE_ORDER = ['discovery', 'scanning', 'analyzing'] as const;
 
 const PHASE_CONFIG = {
-    discovery: { label: 'Discovering Files', color: 'bg-blue-500',    glow: 'shadow-[0_0_8px_rgba(59,130,246,0.6)]',   text: 'text-blue-400' },
-    scanning:  { label: 'Extracting Data',   color: 'bg-amber-400',   glow: 'shadow-[0_0_8px_rgba(251,191,36,0.6)]',  text: 'text-amber-400' },
-    analyzing: { label: 'Linking Deps',      color: 'bg-emerald-500', glow: 'shadow-[0_0_8px_rgba(16,185,129,0.6)]', text: 'text-emerald-400' },
+    discovery: { label: 'Indexing', color: 'bg-blue-500', glow: 'shadow-[0_0_8px_rgba(59,130,246,0.6)]', text: 'text-blue-400' },
+    scanning: { label: 'Analyzing', color: 'bg-amber-400', glow: 'shadow-[0_0_8px_rgba(251,191,36,0.6)]', text: 'text-amber-400' },
+    analyzing: { label: 'Solving', color: 'bg-emerald-500', glow: 'shadow-[0_0_8px_rgba(16,185,129,0.6)]', text: 'text-emerald-400' },
 } as const;
 
 /** Returns the currently active scan phase. */

--- a/frontend/src/components/common/ScanProgressBar.tsx
+++ b/frontend/src/components/common/ScanProgressBar.tsx
@@ -1,41 +1,56 @@
 import React from 'react';
+import { ScanStages } from '../../types';
 
-interface ScanProgressProps {
-    current: number;
-    total: number;
-    label?: string;
+interface ScanProgressBarProps {
+    stages: ScanStages;
     variant?: 'linear' | 'circular';
 }
 
-export const ScanProgressBar: React.FC<ScanProgressProps> = ({ current, total, label = "Scanning", variant = 'linear' }) => {
-    // If total is 0, we can't show percentage, but we show generic spinner or "0"
-    const percentage = total > 0 ? (current / total) * 100 : 0;
+const PHASE_ORDER = ['discovery', 'scanning', 'analyzing'] as const;
+
+const PHASE_CONFIG = {
+    discovery: { label: 'Discovering Files', color: 'bg-blue-500',    glow: 'shadow-[0_0_8px_rgba(59,130,246,0.6)]',   text: 'text-blue-400' },
+    scanning:  { label: 'Extracting Data',   color: 'bg-amber-400',   glow: 'shadow-[0_0_8px_rgba(251,191,36,0.6)]',  text: 'text-amber-400' },
+    analyzing: { label: 'Linking Deps',      color: 'bg-emerald-500', glow: 'shadow-[0_0_8px_rgba(16,185,129,0.6)]', text: 'text-emerald-400' },
+} as const;
+
+/** Returns the currently active scan phase. */
+function activePhase(stages: ScanStages) {
+    for (const key of PHASE_ORDER) {
+        if (!stages[key].done) return key;
+    }
+    return 'analyzing'; // all done
+}
+
+/**
+ * Single sequential progress bar.
+ * Shows one bar at a time that represents the currently active scan phase.
+ * Color and label transition as phases complete.
+ *
+ * linear   variant: labelled bar with count, shown on desktop toolbar
+ * circular variant: compact percentage ring, shown on mobile toolbar
+ */
+export const ScanProgressBar: React.FC<ScanProgressBarProps> = ({ stages, variant = 'linear' }) => {
+    const phase = activePhase(stages);
+    const { current, total, done } = stages[phase];
+    const pct = total > 0 ? Math.min(100, (current / total) * 100) : 0;
+    const cfg = PHASE_CONFIG[phase];
 
     if (variant === 'circular') {
         const radius = 10;
         const circumference = 2 * Math.PI * radius;
-        const offset = circumference - (percentage / 100) * circumference;
+        const offset = circumference - (pct / 100) * circumference;
 
         return (
             <div className="flex items-center gap-2 animate-in fade-in zoom-in-95 duration-200">
                 <div className="relative w-8 h-8 flex items-center justify-center shrink-0">
-                    {/* Background Circle */}
                     <svg className="transform -rotate-90 w-full h-full">
+                        <circle className="text-gray-700" strokeWidth="3" stroke="currentColor" fill="transparent" r={radius} cx="16" cy="16" />
                         <circle
-                            className="text-gray-700"
-                            strokeWidth="3"
-                            stroke="currentColor"
-                            fill="transparent"
-                            r={radius}
-                            cx="16"
-                            cy="16"
-                        />
-                        {/* Progress Circle */}
-                        <circle
-                            className="text-blue-500 transition-all duration-300 ease-out"
+                            className={`${cfg.text} transition-all duration-300 ease-out`}
                             strokeWidth="3"
                             strokeDasharray={circumference}
-                            strokeDashoffset={offset}
+                            strokeDashoffset={done ? 0 : offset}
                             strokeLinecap="round"
                             stroke="currentColor"
                             fill="transparent"
@@ -45,25 +60,34 @@ export const ScanProgressBar: React.FC<ScanProgressProps> = ({ current, total, l
                         />
                     </svg>
                 </div>
-                {/* Feedback Text for Circular Mode (Mobile) */}
                 <div className="flex flex-col justify-center">
-                    <span className="text-[10px] font-bold text-gray-400 uppercase leading-none">{label}</span>
-                    <span className="text-xs font-mono text-gray-300 leading-none mt-0.5">{Math.round(percentage)}%</span>
+                    <span className={`text-[10px] font-bold uppercase leading-none ${cfg.text}`}>{cfg.label}</span>
+                    <span className="text-xs font-mono text-gray-300 leading-none mt-0.5">{Math.round(pct)}%</span>
                 </div>
             </div>
         );
     }
 
+    // Linear: single bar that transitions through phases
     return (
         <div className="flex flex-col w-48 animate-in fade-in zoom-in-95 duration-200">
-            <div className="flex justify-between items-end mb-1 text-[10px] uppercase font-bold tracking-wider text-gray-400">
-                <span className="text-blue-400">{label}</span>
-                <span className="font-mono">{current} / {total}</span>
+            <div className="flex justify-between items-end mb-1">
+                <span className={`text-[10px] font-bold uppercase tracking-wider transition-colors duration-500 ${cfg.text}`}>
+                    {cfg.label}
+                </span>
+                <span className="text-[10px] font-mono text-gray-500">
+                    {done
+                        ? `${total.toLocaleString()} ✓`
+                        : total > 0
+                            ? `${current.toLocaleString()} / ${total.toLocaleString()}`
+                            : '—'
+                    }
+                </span>
             </div>
             <div className="h-1.5 w-full bg-gray-700 rounded-full overflow-hidden">
                 <div
-                    className="h-full bg-blue-500 shadow-[0_0_8px_rgba(59,130,246,0.6)] transition-all duration-200 ease-out"
-                    style={{ width: `${percentage}%` }}
+                    className={`h-full rounded-full transition-all duration-200 ease-out ${cfg.color} ${!done ? cfg.glow : ''}`}
+                    style={{ width: `${done ? 100 : pct}%` }}
                 />
             </div>
         </div>

--- a/frontend/src/context/ActionContext.tsx
+++ b/frontend/src/context/ActionContext.tsx
@@ -41,8 +41,8 @@ const ActionContext = createContext<ActionContextType | undefined>(undefined);
 
 export const ActionProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
     const {
-        packages, analyzePackages, setPackages, setLoading,
-        scanPackages, setScanProgress
+        packages, setPackages, setLoading,
+        scanPackages
     } = usePackageContext();
     const { selectedIds, setSelectedIds, setSelectedPackage, selectedPackage } = useSelectionContext();
     const { activeLibraryPath } = useLibraryContext();
@@ -57,9 +57,9 @@ export const ActionProvider: React.FC<{ children: React.ReactNode }> = ({ childr
         setSelectedIds,
         setSelectedPackage,
         addToast,
-        analyzePackages,
+        undefined, // analyzePackages removed — analysis now done in backend Link Pass
         setLoading,
-        setScanProgress
+        undefined  // setScanProgress removed — progress now driven by scan:stage events
     );
 
 

--- a/frontend/src/context/FilterContext.tsx
+++ b/frontend/src/context/FilterContext.tsx
@@ -54,6 +54,19 @@ export const FilterProvider: React.FC<{ children: React.ReactNode }> = ({ childr
         setCurrentPage(1);
     }, [filterLogic.currentFilter, filterLogic.searchQuery, filterLogic.selectedTags, filterLogic.selectedCreator, filterLogic.selectedType]);
 
+    // Notify the backend Hard Pass about the current page so it gets priority.
+    const { prioritizePackages } = usePackageContext();
+    React.useEffect(() => {
+        if (filterLogic.filteredPkgs.length === 0) return;
+        const start = (currentPage - 1) * itemsPerPage;
+        const pagePaths = filterLogic.filteredPkgs
+            .slice(start, start + itemsPerPage)
+            .map(p => p.filePath);
+        if (pagePaths.length > 0) {
+            prioritizePackages(pagePaths);
+        }
+    }, [currentPage, itemsPerPage, filterLogic.filteredPkgs, prioritizePackages]);
+
 
     // Keybind: Focus Search
     useKeybindSubscription('focus_search', (e) => {

--- a/frontend/src/context/PackageContext.tsx
+++ b/frontend/src/context/PackageContext.tsx
@@ -2,7 +2,7 @@ import React, { createContext, useContext, useEffect } from 'react';
 import { usePackages } from '../hooks/usePackages';
 import { useLibraryContext } from './LibraryContext';
 import { useKeybindSubscription } from './KeybindContext';
-import { VarPackage } from '../types';
+import { VarPackage, ScanStages } from '../types';
 
 interface PackageContextType {
     packages: VarPackage[];
@@ -14,13 +14,24 @@ interface PackageContextType {
     loading: boolean;
     setLoading: (loading: boolean) => void;
     scanError: string | null;
+
+    /** Per-phase progress for the stacked progress bar. */
+    scanStages: ScanStages;
+    setScanStages: (stages: ScanStages) => void;
+
+    /** Legacy alias (scanning phase only) — kept for any component still reading scanProgress. */
     scanProgress: { current: number; total: number };
-    setScanProgress: (progress: { current: number; total: number }) => void;
+
     scanPackages: () => Promise<void>;
     cancelScan: (options?: { resetLoading?: boolean }) => Promise<void>;
-    creatorStatus: Record<string, "normal" | "warning" | "error">;
-    typeStatus: Record<string, "normal" | "warning" | "error">;
-    analyzePackages: (pkgs: VarPackage[]) => VarPackage[]; // Helper exposed?
+
+    /** Bumps the given paths to the front of the Hard Pass queue. */
+    prioritizePackages: (paths: string[]) => void;
+    /** Bumps a single package to the front of the Hard Pass queue. */
+    prioritizePackage: (path: string) => void;
+
+    creatorStatus: Record<string, 'normal' | 'warning' | 'error'>;
+    typeStatus: Record<string, 'normal' | 'warning' | 'error'>;
     isCancelling: boolean;
 }
 
@@ -32,23 +43,17 @@ export const PackageProvider: React.FC<{ children: React.ReactNode }> = ({ child
 
     // Keybind: Refresh
     useKeybindSubscription('refresh', () => {
-        if (!packageLogic.loading) { // Reverted to packageLogic.loading to maintain syntactic correctness
+        if (!packageLogic.loading) {
             packageLogic.scanPackages();
         }
-    }, [packageLogic.scanPackages, packageLogic.loading]); // Added packageLogic.loading to dependencies
+    }, [packageLogic.scanPackages, packageLogic.loading]);
 
-    // Auto-scan when library changes?
-    // Dashboard had this logic:
-    // useEffect(() => { if (activeLibraryPath) handleScan(false); }, [activeLibraryPath]);
-    // The hook usePackages itself doesn't auto-scan on path change, it just updates internal ref/state.
-    // Dashboard useEffect triggered the scan. We should do it here.
-
+    // Auto-scan when library changes
     useEffect(() => {
         if (activeLibraryPath) {
             packageLogic.scanPackages();
         }
     }, [activeLibraryPath]);
-
 
     return (
         <PackageContext.Provider value={packageLogic}>
@@ -59,6 +64,6 @@ export const PackageProvider: React.FC<{ children: React.ReactNode }> = ({ child
 
 export const usePackageContext = () => {
     const context = useContext(PackageContext);
-    if (!context) throw new Error("usePackageContext must be used within PackageProvider");
+    if (!context) throw new Error('usePackageContext must be used within PackageProvider');
     return context;
 };

--- a/frontend/src/context/ServerContext.tsx
+++ b/frontend/src/context/ServerContext.tsx
@@ -24,6 +24,8 @@ interface ServerContextType {
     toggleServer: () => Promise<void>;
     togglePublicAccess: () => Promise<void>;
     updateAuthPollInterval: (val: number) => Promise<void>;
+    startServer: () => Promise<void>;
+    stopServer: () => Promise<void>;
 }
 
 const ServerContext = createContext<ServerContextType | undefined>(undefined);
@@ -42,7 +44,9 @@ export const ServerProvider: React.FC<{ children: React.ReactNode }> = ({ childr
         ...serverLogic,
         toggleServer: () => serverLogic.toggleServer(addToast),
         togglePublicAccess: () => serverLogic.togglePublicAccess(addToast),
-        updateAuthPollInterval: (val: number) => serverLogic.updateAuthPollInterval(val, addToast)
+        updateAuthPollInterval: (val: number) => serverLogic.updateAuthPollInterval(val, addToast),
+        startServer: () => serverLogic.startServer(addToast),
+        stopServer: () => serverLogic.stopServer(addToast),
     };
 
     return (

--- a/frontend/src/features/layout/FilterToolbar.tsx
+++ b/frontend/src/features/layout/FilterToolbar.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { clsx } from 'clsx';
 import { AnimatePresence, motion } from 'framer-motion';
 import {
@@ -32,8 +32,15 @@ export const FilterToolbar: React.FC<FilterToolbarProps> = ({
         filteredPkgs
     } = useFilterContext();
 
-    // PackageContext provides availableTags and loading status
-    const { loading, scanProgress, scanPackages, cancelScan, availableTags } = usePackageContext();
+    // PackageContext provides scanStages (three-phase) and loading state
+    const { loading, scanStages, scanPackages, cancelScan, availableTags } = usePackageContext();
+
+    // Pending search — committed only on Enter or button press (prevents live re-filter mid-scan)
+    const [pendingSearch, setPendingSearch] = useState(searchQuery);
+
+    const handleSearchSubmit = () => {
+        setSearchQuery(pendingSearch);
+    };
 
     const sortOptions = [
         { id: 'name-asc', label: 'Name (A-Z)', icon: <ArrowUpAZ size={14} /> },
@@ -67,17 +74,42 @@ export const FilterToolbar: React.FC<FilterToolbarProps> = ({
                         <PanelLeft size={20} />
                     </button>
 
-                    <div className="flex items-center gap-2 bg-gray-700 px-3 py-2 rounded-lg w-full md:max-w-md">
+                    {/* Search form — submit-only to prevent live filter thrashing mid-scan */}
+                    <form
+                        onSubmit={(e) => { e.preventDefault(); handleSearchSubmit(); }}
+                        className="flex items-center gap-1 bg-gray-700 px-3 py-2 rounded-lg w-full md:max-w-md"
+                    >
                         <Search size={18} className="text-gray-400 shrink-0" />
                         <input
+                            id="search-input"
                             ref={inputRef}
                             className="bg-transparent outline-none w-full text-sm placeholder-gray-500 text-gray-200"
-                            placeholder="Search packages..."
-                            value={searchQuery}
-                            onChange={(e) => setSearchQuery(e.target.value)}
+                            placeholder="Search packages… (Enter to apply)"
+                            value={pendingSearch}
+                            onChange={(e) => setPendingSearch(e.target.value)}
+                            onKeyDown={(e) => { if (e.key === 'Escape') { setPendingSearch(''); setSearchQuery(''); } }}
                         />
+                        {/* Submit button (visible on mobile, hidden on desktop — desktop uses Enter) */}
+                        <button
+                            type="submit"
+                            className="md:hidden p-1 rounded text-gray-400 hover:text-white hover:bg-gray-600 transition-colors shrink-0"
+                            title="Search"
+                        >
+                            <Search size={15} />
+                        </button>
 
-                        {/* Desktop: Sorting Dropdown inside Search Bar (Hidden on Mobile) */}
+                        {pendingSearch && (
+                            <button
+                                type="button"
+                                onClick={() => { setPendingSearch(''); setSearchQuery(''); }}
+                                className="p-1 rounded text-gray-500 hover:text-white transition-colors shrink-0"
+                                title="Clear search"
+                            >
+                                <X size={14} />
+                            </button>
+                        )}
+
+                        {/* Desktop sort dropdown inside search bar */}
                         <div className="hidden md:block relative shrink-0">
                             <button
                                 onClick={() => setIsSortDropdownOpen(!isSortDropdownOpen)}
@@ -126,7 +158,7 @@ export const FilterToolbar: React.FC<FilterToolbarProps> = ({
                                 />
                             )}
                         </div>
-                    </div>
+                    </form>
                 </div>
 
                 {/* Right Group: Actions */}
@@ -241,10 +273,10 @@ export const FilterToolbar: React.FC<FilterToolbarProps> = ({
                         {loading ? (
                             <>
                                 <div className="md:hidden">
-                                    <ScanProgressBar current={scanProgress.current} total={scanProgress.total} variant="circular" />
+                                    <ScanProgressBar stages={scanStages} variant="circular" />
                                 </div>
                                 <div className="hidden md:block">
-                                    <ScanProgressBar current={scanProgress.current} total={scanProgress.total} variant="linear" />
+                                    <ScanProgressBar stages={scanStages} variant="linear" />
                                 </div>
                             </>
                         ) : (

--- a/frontend/src/features/library/PackageCard.tsx
+++ b/frontend/src/features/library/PackageCard.tsx
@@ -4,6 +4,7 @@ import clsx from 'clsx';
 import { AlertCircle, Check, AlertTriangle, Power, Copy } from 'lucide-react';
 import { motion } from 'framer-motion';
 import { formatBytes } from '../../utils/format';
+import PackageSkeleton from './components/PackageSkeleton';
 
 interface PackageCardProps {
     pkg: VarPackage;
@@ -23,29 +24,29 @@ interface PackageCardProps {
 const PackageCard = memo(({ pkg, onContextMenu, onSelect, isSelected, isAnchor, viewMode = 'grid', censorThumbnails = false, blurAmount = 10, hidePackageNames = false, hideCreatorNames = false, isHighlighted = false, startAnimationTs }: PackageCardProps) => {
     const cardRef = useRef<HTMLDivElement>(null);
 
-    // optimize: Do not store base64 in state if it comes from props (prevents duplication)
+    // ── All hooks must be declared unconditionally (Rules of Hooks) ───────────
+    // Do NOT add early returns before these declarations.
+
+    // Async thumbnail for web mode / desktop lazy-load
     const [asyncThumb, setAsyncThumb] = useState<string | undefined>(undefined);
+    const [isVisible, setIsVisible] = useState(false);
+
     const thumbSrc = pkg.thumbnailBase64
         ? `data:image/jpeg;base64,${pkg.thumbnailBase64}`
         : asyncThumb;
 
-    const [isVisible, setIsVisible] = useState(false);
-
     // Scroll Into View when Anchor
     useEffect(() => {
         if (isAnchor && cardRef.current) {
-            // Use subtle timeout to allow layout to settle if needed, or run immediately.
-            // 'nearest' ensures minimal scrolling just to get it in view.
             cardRef.current.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
         }
     }, [isAnchor]);
 
-    const handleClick = (e: React.MouseEvent) => {
-        onSelect(pkg, e);
-    };
-
     // Lazy Loading Logic
     useEffect(() => {
+        // Skip for skeleton phase — the zip hasn't been opened yet
+        if (pkg.scanPhase === 'discovered') return;
+
         if (!window.go) {
             // Web Mode: Use API URL directly
             if (pkg.hasThumbnail && !pkg.thumbnailBase64) {
@@ -56,31 +57,55 @@ const PackageCard = memo(({ pkg, onContextMenu, onSelect, isSelected, isAnchor, 
         }
 
         // Desktop Mode: Intersection Observer
-        if (!pkg.hasThumbnail || thumbSrc) return; // Already have it or none exists
+        if (!pkg.hasThumbnail || thumbSrc) return;
 
         const observer = new IntersectionObserver(([entry]) => {
             if (entry.isIntersecting) {
                 setIsVisible(true);
-                observer.disconnect(); // Only need trigger once
+                observer.disconnect();
             }
         }, { rootMargin: '200px' });
 
         if (cardRef.current) observer.observe(cardRef.current);
-
         return () => observer.disconnect();
-    }, [pkg.filePath, pkg.hasThumbnail, thumbSrc]);
+    }, [pkg.filePath, pkg.hasThumbnail, pkg.scanPhase, thumbSrc]);
 
     useEffect(() => {
-        // Fetch for Desktop when visible
+        if (pkg.scanPhase === 'discovered') return;
         if (window.go && isVisible && pkg.hasThumbnail && !thumbSrc) {
             window.go.main.App.GetPackageThumbnail(pkg.filePath)
                 .then((b64: string) => {
                     if (b64) setAsyncThumb(`data:image/jpeg;base64,${b64}`);
                 })
-                .catch((e: any) => console.error("Thumb load failed:", e));
+                .catch((e: any) => console.error('Thumb load failed:', e));
         }
-    }, [isVisible, pkg.hasThumbnail, pkg.filePath, thumbSrc]);
+    }, [isVisible, pkg.hasThumbnail, pkg.filePath, pkg.scanPhase, thumbSrc]);
 
+    // ── Click handler ─────────────────────────────────────────────────────────
+    const handleClick = (e: React.MouseEvent) => {
+        // Bump this package to the front of the Hard Pass queue on any click.
+        if (pkg.scanPhase !== 'analyzed' && window.go) {
+            // @ts-ignore
+            window.go.main.App.PrioritizePackage(pkg.filePath).catch(() => {});
+        }
+        onSelect(pkg, e);
+    };
+
+    // ── Light Pass skeleton ───────────────────────────────────────────────────
+    // Render a placeholder until the Hard Pass has opened the zip.
+    // All hooks above have already run at this point — no Rules of Hooks violation.
+    if (pkg.scanPhase === 'discovered') {
+        return (
+            <div
+                ref={cardRef}
+                onClick={handleClick}
+                onContextMenu={(e) => onContextMenu(e, pkg)}
+                style={{ cursor: 'pointer' }}
+            >
+                <PackageSkeleton viewMode={viewMode} />
+            </div>
+        );
+    }
 
     // Visual State Logic
     let statusClass = "border-gray-700 opacity-60 grayscale";

--- a/frontend/src/features/library/PackageCard.tsx
+++ b/frontend/src/features/library/PackageCard.tsx
@@ -4,7 +4,6 @@ import clsx from 'clsx';
 import { AlertCircle, Check, AlertTriangle, Power, Copy } from 'lucide-react';
 import { motion } from 'framer-motion';
 import { formatBytes } from '../../utils/format';
-import PackageSkeleton from './components/PackageSkeleton';
 
 interface PackageCardProps {
     pkg: VarPackage;
@@ -91,21 +90,7 @@ const PackageCard = memo(({ pkg, onContextMenu, onSelect, isSelected, isAnchor, 
         onSelect(pkg, e);
     };
 
-    // ── Light Pass skeleton ───────────────────────────────────────────────────
-    // Render a placeholder until the Hard Pass has opened the zip.
-    // All hooks above have already run at this point — no Rules of Hooks violation.
-    if (pkg.scanPhase === 'discovered') {
-        return (
-            <div
-                ref={cardRef}
-                onClick={handleClick}
-                onContextMenu={(e) => onContextMenu(e, pkg)}
-                style={{ cursor: 'pointer' }}
-            >
-                <PackageSkeleton viewMode={viewMode} />
-            </div>
-        );
-    }
+
 
     // Visual State Logic
     let statusClass = "border-gray-700 opacity-60 grayscale";
@@ -187,6 +172,8 @@ const PackageCard = memo(({ pkg, onContextMenu, onSelect, isSelected, isAnchor, 
                         <div className={clsx("w-full h-full flex items-center justify-center border", pkg.isCorrupt ? "bg-red-900/40 border-red-500/30 text-red-500" : "text-gray-700 border-gray-700")}>
                             {pkg.isCorrupt ? (
                                 <span className="text-[10px] font-bold rotate-[-15deg]">ERROR</span>
+                            ) : pkg.scanPhase === 'discovered' ? (
+                                <div className="w-4 h-4 border-2 border-gray-600 border-t-gray-400 rounded-full animate-spin" />
                             ) : (
                                 <span className="text-[8px] font-bold">{pkg.hasThumbnail ? "..." : "NO IMG"}</span>
                             )}
@@ -254,6 +241,8 @@ const PackageCard = memo(({ pkg, onContextMenu, onSelect, isSelected, isAnchor, 
                             <div className="flex flex-col items-center justify-center text-red-500 font-bold opacity-80 rotate-[-15deg] border-4 border-red-500/50 p-2 rounded-xl">
                                 <span className="text-2xl tracking-widest">CORRUPT</span>
                             </div>
+                        ) : pkg.scanPhase === 'discovered' ? (
+                            <div className="w-10 h-10 border-4 border-gray-600 border-t-gray-400 rounded-full animate-spin" />
                         ) : (
                             <span className="text-4xl font-bold text-gray-700 select-none opacity-50">{pkg.hasThumbnail ? "..." : "VAR"}</span>
                         )}

--- a/frontend/src/features/library/components/PackageSkeleton.tsx
+++ b/frontend/src/features/library/components/PackageSkeleton.tsx
@@ -1,0 +1,45 @@
+import { memo } from 'react';
+
+interface PackageSkeletonProps {
+    viewMode?: 'grid' | 'list';
+}
+
+/**
+ * Skeleton card shown during the Light Pass (scanPhase === 'discovered').
+ * Matches PackageCard dimensions exactly to prevent layout shift when real data arrives.
+ */
+const PackageSkeleton = memo(({ viewMode = 'grid' }: PackageSkeletonProps) => {
+    if (viewMode === 'list') {
+        return (
+            <div className="flex items-center gap-3 px-3 py-2 rounded-lg bg-gray-800/50 animate-pulse">
+                {/* Thumbnail stub */}
+                <div className="w-10 h-10 rounded bg-gray-700 shrink-0" />
+                {/* Text stubs */}
+                <div className="flex-1 min-w-0 flex flex-col gap-1.5">
+                    <div className="h-3 bg-gray-700 rounded w-2/5" />
+                    <div className="h-2.5 bg-gray-700/60 rounded w-1/4" />
+                </div>
+                {/* Size stub */}
+                <div className="h-2.5 bg-gray-700/40 rounded w-10 shrink-0" />
+            </div>
+        );
+    }
+
+    return (
+        <div className="flex flex-col rounded-xl overflow-hidden bg-gray-800/60 border border-gray-700/40 animate-pulse">
+            {/* Thumbnail area */}
+            <div className="relative aspect-[4/3] bg-gray-700/60 flex items-center justify-center">
+                {/* Loading pulse ring */}
+                <div className="w-8 h-8 rounded-full border-2 border-gray-600 border-t-gray-400 animate-spin opacity-40" />
+            </div>
+            {/* Card footer */}
+            <div className="px-2.5 py-2 flex flex-col gap-1.5">
+                <div className="h-3 bg-gray-700 rounded w-4/5" />
+                <div className="h-2.5 bg-gray-600/50 rounded w-1/2" />
+            </div>
+        </div>
+    );
+});
+
+PackageSkeleton.displayName = 'PackageSkeleton';
+export default PackageSkeleton;

--- a/frontend/src/features/settings/tabs/ApplicationTab.tsx
+++ b/frontend/src/features/settings/tabs/ApplicationTab.tsx
@@ -1,10 +1,12 @@
 // Generic Components
+import { useState, useEffect, useCallback } from 'react';
 import { SettingGroup } from '../components/SettingGroup';
 import { SettingItem } from '../components/SettingItem';
 import { Toggle } from '../../../components/ui/Toggle';
 import { Input } from '../../../components/ui/Input';
 import { Slider } from '../../../components/ui/Slider';
 import { motion } from 'framer-motion';
+import { Trash2 } from 'lucide-react';
 
 const container = {
     hidden: { opacity: 0 },
@@ -44,6 +46,39 @@ const ApplicationTab = ({
     maxToasts,
     setMaxToasts
 }: ApplicationTabProps) => {
+    // ── Thumbnail cache ───────────────────────────────────────────────────────
+    const [cacheSize, setCacheSize] = useState<number | null>(null);
+    const [cacheClearing, setCacheClearing] = useState(false);
+
+    const refreshCacheSize = useCallback(async () => {
+        if (!window.go) return;
+        try {
+            // @ts-ignore
+            const bytes = await window.go.main.App.GetThumbnailCacheSize();
+            setCacheSize(bytes);
+        } catch { /* non-fatal */ }
+    }, []);
+
+    useEffect(() => { refreshCacheSize(); }, [refreshCacheSize]);
+
+    const handleClearCache = async () => {
+        if (!window.go) return;
+        setCacheClearing(true);
+        try {
+            // @ts-ignore
+            await window.go.main.App.ClearThumbnailCache();
+            await refreshCacheSize();
+        } catch { /* non-fatal */ } finally {
+            setCacheClearing(false);
+        }
+    };
+
+    const formatBytes = (b: number) => {
+        if (b < 1024) return `${b} B`;
+        if (b < 1024 * 1024) return `${(b / 1024).toFixed(1)} KB`;
+        return `${(b / (1024 * 1024)).toFixed(1)} MB`;
+    };
+
     return (
         <motion.div
             variants={container}
@@ -114,6 +149,31 @@ const ApplicationTab = ({
                                     checked={minimizeOnClose}
                                     onChange={setMinimizeOnClose}
                                 />
+                            </SettingItem>
+                        </SettingGroup>
+                    )}
+
+                    {/* Thumbnail Cache */}
+                    {!isWeb && (
+                        <SettingGroup title="Thumbnail Cache" variants={item}>
+                            <SettingItem
+                                title="Package Cover Cache"
+                                tooltip="YAVAM caches one cover image per package so it doesn't need to re-open .var files on every startup. Only package covers are stored — not content thumbnails."
+                            >
+                                <div className="flex items-center gap-3">
+                                    <span className="text-sm font-mono text-gray-400">
+                                        {cacheSize === null ? '—' : formatBytes(cacheSize)}
+                                    </span>
+                                    <button
+                                        id="clear-thumbnail-cache-btn"
+                                        onClick={handleClearCache}
+                                        disabled={cacheClearing || cacheSize === 0}
+                                        className="flex items-center gap-1.5 px-3 py-1.5 text-xs rounded-lg bg-red-500/10 text-red-400 hover:bg-red-500/20 hover:text-red-300 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+                                    >
+                                        <Trash2 size={13} />
+                                        {cacheClearing ? 'Clearing…' : 'Clear Cache'}
+                                    </button>
+                                </div>
                             </SettingItem>
                         </SettingGroup>
                     )}

--- a/frontend/src/features/system/SystemModals.tsx
+++ b/frontend/src/features/system/SystemModals.tsx
@@ -59,7 +59,8 @@ export const SystemModals: React.FC<SystemModalsProps> = ({
     // Consume Contexts
     const {
         serverEnabled, serverPort, localIP, serverLogs, publicAccess, authPollInterval,
-        toggleServer, togglePublicAccess, updateAuthPollInterval
+        toggleServer, togglePublicAccess, updateAuthPollInterval,
+        startServer, stopServer, setServerPort,
     } = useServerContext();
 
     // ServerContext misses setServerPort? Dashboard had internal logic but useServer manages it?
@@ -101,10 +102,7 @@ export const SystemModals: React.FC<SystemModalsProps> = ({
                 onToggleServer={toggleServer}
                 onTogglePublicAccess={togglePublicAccess}
                 setAuthPollInterval={updateAuthPollInterval}
-                // setServerPort? If context doesn't expose, we can't set. 
-                // SettingsDialog expects setServerPort probably. 
-                // Passing empty fn for now.
-                setServerPort={() => { }}
+                setServerPort={setServerPort}
 
                 // App Props
                 isGuest={isGuest}
@@ -118,12 +116,13 @@ export const SystemModals: React.FC<SystemModalsProps> = ({
                 maxToasts={maxToasts}
                 setMaxToasts={setMaxToasts}
 
-                // Actions
-                onStartServer={() => !serverEnabled && toggleServer()}
-                onStopServer={() => serverEnabled && toggleServer()}
+                // Actions — start/stop call the real backend RPCs (not the config toggle)
+                onStartServer={startServer}
+                onStopServer={stopServer}
                 handleClearData={handleClearData}
                 addToast={addToast}
             />
+
 
             {/* Upgrade Modal */}
             <UpgradeModal

--- a/frontend/src/hooks/useLibrary.ts
+++ b/frontend/src/hooks/useLibrary.ts
@@ -149,7 +149,14 @@ export const useLibrary = () => {
                         const isValid = cfg.libraries.some((l: string) => l.toLowerCase() === current.toLowerCase());
 
                         if ((!current || !isValid) && cfg.libraries.length > 0) {
-                            selectLibrary(cfg.libraries[0]);
+                            const first = cfg.libraries[0];
+                            setActiveLibraryPath(first);
+                            setActiveLibIndex(0);
+                            localStorage.setItem("activeLibraryPath", first);
+                        } else if (isValid) {
+                            // Sync index if it was valid
+                            const idx = cfg.libraries.findIndex((l: string) => l.toLowerCase() === current.toLowerCase());
+                            if (idx !== -1) setActiveLibIndex(idx);
                         }
                     }
                 }
@@ -174,7 +181,13 @@ export const useLibrary = () => {
 
                             // If empty or invalid, select first available
                             if ((!current || !isValid) && data.libraries.length > 0) {
-                                selectLibrary(data.libraries[0]);
+                                const first = data.libraries[0];
+                                setActiveLibraryPath(first);
+                                setActiveLibIndex(0);
+                                localStorage.setItem("activeLibraryPath", first);
+                            } else if (isValid) {
+                                const idx = data.libraries.findIndex((l: string) => l.toLowerCase() === current.toLowerCase());
+                                if (idx !== -1) setActiveLibIndex(idx);
                             }
                         }
                     }

--- a/frontend/src/hooks/usePackages.ts
+++ b/frontend/src/hooks/usePackages.ts
@@ -33,6 +33,12 @@ export const usePackages = (activeLibraryPath: string) => {
         if (scanAbortController.current) scanAbortController.current.abort();
         if (window.go) {
             await window.go.main.App.CancelScan();
+        } else {
+            // Await the cancel so the modal stays visible and the new scan does not
+            // start until the backend scan goroutine has actually stopped.
+            // Flow: abort() closes the connection → Go cancels r.Context() → scan context
+            // cancelled → runThreePhase returns → defer scanWg.Done() fires → Wait() unblocks.
+            await fetchWithAuth('/api/scan/cancel').catch(() => { /* non-fatal */ });
         }
         if (resetLoading) setLoading(false);
         setIsCancelling(false);
@@ -226,7 +232,12 @@ export const usePackages = (activeLibraryPath: string) => {
                 setLoading(false);
             }
         } else {
-            // Web (server) mode — SSE/REST fallback
+            // Web (server) mode — SSE/REST fallback.
+            // MUST await: this keeps scanPackages() suspended while the scan is running,
+            // matching the desktop behaviour (await ScanPackages()). This ensures that
+            // when the library changes and a new scanPackages() call runs cancelScan(),
+            // the previous invocation's event listeners have already been torn down and
+            // the server scan has completed before the new one starts.
             if (scanAbortController.current) scanAbortController.current.abort();
             const controller = new AbortController();
             scanAbortController.current = controller;
@@ -236,7 +247,10 @@ export const usePackages = (activeLibraryPath: string) => {
                     { signal: controller.signal }
                 );
             } catch (e: any) {
+                // AbortError = we cancelled on purpose; don't clear loading here since
+                // cancelScan() already handles state via resetLoading.
                 if (e.name !== 'AbortError') {
+                    setScanError(e.message || String(e));
                     setLoading(false);
                 }
             }

--- a/frontend/src/hooks/usePackages.ts
+++ b/frontend/src/hooks/usePackages.ts
@@ -1,254 +1,69 @@
 import { useState, useRef, useCallback, useMemo, useEffect } from 'react';
-import { VarPackage } from '../types';
+import { VarPackage, PackageAnalysis, ScanStageProgress, ScanStages } from '../types';
 import { fetchWithAuth } from '../services/api';
-import { analyzeGraph } from '../utils/packageDependencyAnalysis';
-import { PACKAGES } from '../constants';
 
-
-interface ScanProgress {
-    current: number;
-    total: number;
-}
+const EMPTY_STAGES: ScanStages = {
+    discovery: { current: 0, total: 0, done: false },
+    scanning:  { current: 0, total: 0, done: false },
+    analyzing: { current: 0, total: 0, done: false },
+};
 
 export const usePackages = (activeLibraryPath: string) => {
     const [packages, setPackages] = useState<VarPackage[]>([]);
     const [scanError, setScanError] = useState<string | null>(null);
-    const [filteredPkgs, setFilteredPkgs] = useState<VarPackage[]>([]); // This might move to useFilters later, but for now scanPackages clears it.
+    const [filteredPkgs, setFilteredPkgs] = useState<VarPackage[]>([]);
     const [availableTags, setAvailableTags] = useState<string[]>([]);
     const [loading, setLoading] = useState(false);
-    const loadingRef = useRef(false); // Track loading synchronously
+    const loadingRef = useRef(false);
     useEffect(() => { loadingRef.current = loading; }, [loading]);
 
-    const [scanProgress, setScanProgress] = useState<ScanProgress>({ current: 0, total: 0 });
+    const [scanStages, setScanStages] = useState<ScanStages>(EMPTY_STAGES);
     const scanSessionId = useRef(0);
     const scanAbortController = useRef<AbortController | null>(null);
     const [isCancelling, setIsCancelling] = useState(false);
-    const knownPathsRef = useRef(new Set<string>()); // Sync tracker for buffer
 
-    // Cancel Scan Function (Moved Up)
+    // Sync tracker: normalised paths we've already added to avoid ghost duplicates.
+    const knownPathsRef = useRef(new Set<string>());
+
+    // ── Cancel ────────────────────────────────────────────────────────────────
     const cancelScan = useCallback(async (options: { resetLoading?: boolean } = {}) => {
         const { resetLoading = true } = options;
         if (!loadingRef.current) return;
-
         setIsCancelling(true);
-
-
         if (scanAbortController.current) scanAbortController.current.abort();
-
         if (window.go) {
             await window.go.main.App.CancelScan();
         }
-
-        if (resetLoading) {
-            setLoading(false);
-        }
+        if (resetLoading) setLoading(false);
         setIsCancelling(false);
     }, []);
 
-    // Helper: Analyze Packages (Moved from Dashboard)
-    const analyzePackages = useCallback((pkgs: VarPackage[]): VarPackage[] => {
-
-        // 1. Build Index and Group by "Creator.Package"
-        const pkgIds = new Set<string>();
-        const groups = new Map<string, VarPackage[]>();
-
-        pkgs.forEach(p => {
-            if (p.isCorrupt) return;
-            if (p.meta && p.meta.creator && p.meta.packageName) {
-                const id = `${p.meta.creator}.${p.meta.packageName}.${p.meta.version}`;
-                pkgIds.add(id);
-
-                const groupKey = `${p.meta.creator}.${p.meta.packageName}`;
-                if (!groups.has(groupKey)) groups.set(groupKey, []);
-                groups.get(groupKey)?.push(p);
-            }
-        });
-
-        // 2. Identify Obsolete vs Redundant Packages
-        const obsoletePaths = new Map<string, string>();
-        const redundantPaths = new Map<string, string>();
-
-        groups.forEach((groupPkgs) => {
-            if (groupPkgs.length > 1) {
-                // Helper to normalize version to Int
-                // Robust Version Comparator
-                const compareVersions = (v1: string, v2: string) => {
-                    if (v1 === v2) return 0;
-                    const parts1 = v1.split('.').map(p => parseInt(p, 10));
-                    const parts2 = v2.split('.').map(p => parseInt(p, 10));
-
-                    const len = Math.max(parts1.length, parts2.length);
-                    for (let i = 0; i < len; i++) {
-                        const n1 = parts1[i] || 0;
-                        const n2 = parts2[i] || 0;
-                        if (n1 > n2) return 1;
-                        if (n1 < n2) return -1;
-                    }
-                    return 0;
-                };
-
-                groupPkgs.sort((a, b) => {
-                    // 1. Prioritize Enabled Packages (Active beats Disabled)
-                    if (a.isEnabled && !b.isEnabled) return -1;
-                    if (!a.isEnabled && b.isEnabled) return 1;
-
-                    // 2. Prioritize Newer Versions (Descending)
-                    // vB - vA: If B > A, result > 0 (B first)
-                    return compareVersions(b.meta.version || "0", a.meta.version || "0");
-                });
-
-                // Head is groupPkgs[0]. All others are secondary.
-                const head = groupPkgs[0];
-                const headVer = head.meta.version || "0";
-                const headFile = head.fileName;
-
-                for (let i = 1; i < groupPkgs.length; i++) {
-                    const currentVer = groupPkgs[i].meta.version || "0";
-                    const cmp = compareVersions(currentVer, headVer);
-
-                    // If Equal (0) -> Exact Duplicate
-                    if (cmp === 0) {
-                        redundantPaths.set(groupPkgs[i].filePath, `Duplicate of active package: ${head.filePath}`);
-                        // Debug Log
-                        // @ts-ignore
-                        if (window.go?.main?.App?.Log) window.go.main.App.Log("DEBUG", `[Analysis] Duplicate: ${groupPkgs[i].fileName} == ${headFile} (v${currentVer})`);
-                    } else {
-                        // Else Obsolete (current < head)
-                        obsoletePaths.set(groupPkgs[i].filePath, `Obsoleted by v${head.meta.version} in: ${head.filePath}`);
-                        // Debug Log
-                        // @ts-ignore
-                        if (window.go?.main?.App?.Log) window.go.main.App.Log("DEBUG", `[Analysis] Obsolete: ${groupPkgs[i].fileName} (v${currentVer}) < ${headFile} (v${headVer})`);
-                    }
-                }
-            }
-        });
-
-        // 2b. Build Sets for fast lookup
-        const baseIdSet = new Set<string>();
-        const enabledBaseIdSet = new Set<string>(); // New: Track enabled packages by BaseID
-        pkgs.forEach(p => {
-            if (p.meta && p.meta.creator && p.meta.packageName) {
-                const base = `${p.meta.creator}.${p.meta.packageName}`.toLowerCase();
-                baseIdSet.add(base);
-                if (p.isEnabled && !p.isCorrupt) {
-                    enabledBaseIdSet.add(base);
-                }
-            }
-        });
-
-        // 3. Exact Duplicate Detection
-        const exactDupesMap = new Map<string, number>();
-        const enabledDupesMap = new Map<string, number>();
-
-        pkgs.forEach(p => {
-            if (p.isCorrupt) return;
-            if (!p.meta || !p.meta.creator || !p.meta.packageName) return;
-            const key = `${p.meta.creator}.${p.meta.packageName}.${p.meta.version}.${p.size}`;
-            exactDupesMap.set(key, (exactDupesMap.get(key) || 0) + 1);
-            if (p.isEnabled) {
-                enabledDupesMap.set(key, (enabledDupesMap.get(key) || 0) + 1);
-            }
-        });
-
-        // 4. Graph Analysis (Orphan Detection)
-        const { orphans, reverseDeps } = analyzeGraph(pkgs);
-
-        return pkgs.map(p => {
-            let isDuplicate = false; // Maps to OBSOLETE (Yellow)
-            let isExactDuplicate = false; // Maps to DUPLICATE (Purple)
-            let missingDeps: string[] = [];
-            let obsoletedBy: string | undefined = undefined;
-
-            if (obsoletePaths.has(p.filePath)) {
-                isDuplicate = true;
-                obsoletedBy = obsoletePaths.get(p.filePath);
-            }
-            if (redundantPaths.has(p.filePath)) {
-                isExactDuplicate = true; // Same version = Duplicate
-                obsoletedBy = redundantPaths.get(p.filePath);
-            }
-
-            if (p.meta && p.meta.creator && p.meta.packageName) {
-                const exactKey = `${p.meta.creator}.${p.meta.packageName}.${p.meta.version}.${p.size}`;
-                if ((exactDupesMap.get(exactKey) || 0) > 1) {
-                    isExactDuplicate = true;
-                    if (!obsoletedBy) obsoletedBy = "Identical copy exists in library";
-                }
-            }
-
-            if (p.isEnabled && p.meta && p.meta.dependencies) {
-                Object.keys(p.meta.dependencies).forEach(depId => {
-                    let isMissing = !pkgIds.has(depId);
-                    const cleanDep = depId.toLowerCase();
-
-                    // If exact match fails, try resolving...
-                    if (isMissing) {
-                        // 1. Is it a .latest pointer?
-                        if (cleanDep.endsWith('.latest')) {
-                            const baseDep = cleanDep.slice(0, -7);
-                            if (enabledBaseIdSet.has(baseDep)) isMissing = false;
-                        } else {
-                            // 2. Is it a Version Mismatch? (e.g. asking for v1, we have v2)
-                            // Fix: Recursive Base Lookup.
-                            // Since Package Names AND Versions can contain dots, we can't simply split.
-                            // We progressively strip the suffix until we find a known Base ID.
-                            // E.g. "A.B.C.1.0" -> Check "A.B.C.1" (No) -> Check "A.B.C" (Yes!)
-                            let tempBase = cleanDep;
-                            let matchFound = false;
-
-                            // Safety break to prevent infinite loops, though lastIndexOf handles it
-                            while (tempBase.includes('.')) {
-                                const lastDot = tempBase.lastIndexOf('.');
-                                if (lastDot === -1) break;
-
-                                tempBase = tempBase.substring(0, lastDot);
-                                if (enabledBaseIdSet.has(tempBase)) {
-                                    matchFound = true;
-                                    break;
-                                }
-                            }
-
-                            if (matchFound) {
-                                isMissing = false;
-                            } else if (window.go?.main?.App?.Log) {
-                                // Debug info for persistent mismatches
-                                // @ts-ignore
-                                window.go.main.App.Log("DEBUG", `[MismatchAnalysis] ${p.fileName} needs ${cleanDep}. Recursive lookup failed.`);
-                            }
-                        }
-                    }
-
-                    if (isMissing) {
-                        if (depId !== PACKAGES.CORE.ID && !depId.startsWith("system.")) {
-                            missingDeps.push(depId);
-                        }
-                    }
-                });
-            }
-
-            return {
-                ...p,
-                isDuplicate,
-                isExactDuplicate,
-                missingDeps,
-                isOrphan: orphans.has(p.filePath),
-                referencedBy: Array.from(reverseDeps.get(`${p.meta.creator}.${p.meta.packageName}.${p.meta.version}`.toLowerCase()) || [])
-            };
-        });
+    // ── Priority bump ─────────────────────────────────────────────────────────
+    /**
+     * Tell the backend's Hard Pass to scan these paths next.
+     * Called by FilterContext when the page changes, and by PackageCard on click.
+     */
+    const prioritizePackages = useCallback((paths: string[]) => {
+        if (!window.go || paths.length === 0) return;
+        window.go.main.App.SetCurrentPage(paths).catch(() => { /* non-fatal */ });
     }, []);
 
+    const prioritizePackage = useCallback((path: string) => {
+        if (!window.go) return;
+        window.go.main.App.PrioritizePackage(path).catch(() => { /* non-fatal */ });
+    }, []);
+
+    // ── Scan ──────────────────────────────────────────────────────────────────
     const scanPackages = useCallback(async () => {
         if (!activeLibraryPath) {
             setPackages([]);
             setFilteredPkgs([]);
             setAvailableTags([]);
-            setScanProgress({ current: 0, total: 0 });
+            setScanStages(EMPTY_STAGES);
             return;
         }
 
-        // Check if loading to trigger implicit cancellation
         if (loadingRef.current) {
-            // Await cancellation but keep loading state true to prevent UI flash
             await cancelScan({ resetLoading: false });
         }
 
@@ -257,231 +72,238 @@ export const usePackages = (activeLibraryPath: string) => {
         setScanError(null);
         setPackages([]);
         setFilteredPkgs([]);
-        setScanProgress({ current: 0, total: 0 });
+        setScanStages(EMPTY_STAGES);
         knownPathsRef.current.clear();
 
-        // Initialize Listeners (Common for both Desktop and Web/Polyfill)
         if (window.runtime) {
-            // Remove old listeners to be safe
-            window.runtime.EventsOff("package:scanned");
-            window.runtime.EventsOff("scan:progress");
-            window.runtime.EventsOff("scan:complete");
-            window.runtime.EventsOff("scan:error");
+            // Remove stale listeners
+            window.runtime.EventsOff('package:discovered');
+            window.runtime.EventsOff('package:scanned');
+            window.runtime.EventsOff('scan:analysis:complete');
+            window.runtime.EventsOff('scan:stage');
+            window.runtime.EventsOff('scan:complete');
+            window.runtime.EventsOff('scan:error');
 
-            let packageBuffer: VarPackage[] = [];
-            let lastUpdate = Date.now();
-            let updateTimer: any = null;
             const currentScanPath = activeLibraryPath;
 
+            // ── Buffered batch flush for discovered/scanned ───────────────────
+            let discoveredBuffer: VarPackage[] = [];
+            let scannedBuffer: VarPackage[] = [];
+            let lastFlush = Date.now();
+            let flushTimer: ReturnType<typeof setTimeout> | null = null;
 
-
-            const flushBuffer = () => {
-                if (scanSessionId.current !== currentId) return;
-                if (packageBuffer.length === 0) return;
-
-                // Optimization: Filter using Ref (O(1)) instead of scanning State (O(N))
-                const uniqueBatch: VarPackage[] = [];
-                for (const p of packageBuffer) {
-                    // Fix: Normalize path to handle Windows case-insensitivity AND slash direction
-                    // This prevents "Ghost Duplicates" (C:\File vs c:/file)
-                    const normalizedPath = p.filePath.replace(/\\/g, '/').toLowerCase();
-
-                    if (!knownPathsRef.current.has(normalizedPath)) {
-                        knownPathsRef.current.add(normalizedPath);
-                        uniqueBatch.push(p);
-                    } else {
-                        // LOGGING: Ghost Duplicate Detection
-                        // @ts-ignore
-                        if (window.go && window.go.main && window.go.main.App && window.go.main.App.Log) {
-                            // @ts-ignore
-                            window.go.main.App.Log("WARN", `[Ghost] Dropped duplicate path: ${p.filePath} (Normalized collision with: ${normalizedPath})`);
-                        }
-                    }
-                }
-                packageBuffer = [];
-
-                if (uniqueBatch.length === 0) return;
-
-                setPackages(prev => [...prev, ...uniqueBatch]);
+            const scheduleFlush = (immediate = false) => {
+                if (flushTimer) clearTimeout(flushTimer);
+                const delay = immediate ? 0 : 200;
+                flushTimer = setTimeout(() => {
+                    flushTimer = null;
+                    batchFlush();
+                    lastFlush = Date.now();
+                }, delay);
             };
 
-            // @ts-ignore
-            window.runtime.EventsOn("package:scanned", (data: VarPackage) => {
+            const batchFlush = () => {
                 if (scanSessionId.current !== currentId) return;
-                const pkg = { ...data, isEnabled: data.filePath.endsWith(".var") };
 
-                const normalizedPkgPath = pkg.filePath.replace(/\\/g, '/').toLowerCase();
-                const normalizedLibPath = currentScanPath.replace(/\\/g, '/').toLowerCase();
-                if (!normalizedPkgPath.includes(normalizedLibPath)) return;
+                const toDiscover = discoveredBuffer.splice(0);
+                const toScan = scannedBuffer.splice(0);
 
-                packageBuffer.push(pkg);
-                const now = Date.now();
-                if (now - lastUpdate > 500) { // Throttled to 500ms
-                    flushBuffer();
-                    lastUpdate = now;
-                } else if (!updateTimer) {
-                    updateTimer = setTimeout(() => {
-                        flushBuffer();
-                        lastUpdate = Date.now();
-                        updateTimer = null;
-                    }, 500); // Throttled to 500ms
-                }
-            });
+                if (toDiscover.length === 0 && toScan.length === 0) return;
 
-            // @ts-ignore
-            window.runtime.EventsOn("scan:progress", (data: any) => {
-                if (scanSessionId.current !== currentId) return;
-                setScanProgress({ current: data.current, total: data.total });
-            });
-            // @ts-ignore
-            window.runtime.EventsOn("scan:complete", () => {
-                if (scanSessionId.current !== currentId) return;
-                if (updateTimer) clearTimeout(updateTimer);
-                flushBuffer();
                 setPackages(prev => {
-                    const analyzed = analyzePackages(prev);
+                    // Build a mutable map for fast updates.
+                    const map = new Map<string, VarPackage>(prev.map(p => [p.filePath, p]));
 
-                    // LOGGING: Analysis Results
-                    // @ts-ignore
-                    if (window.go && window.go.main && window.go.main.App && window.go.main.App.Log) {
-                        // @ts-ignore
-                        window.go.main.App.Log("INFO", `[Analysis] Scan Complete. Processed ${analyzed.length} packages.`);
-                        analyzed.forEach(p => {
-                            if (p.obsoletedBy) {
-                                const status = p.isExactDuplicate ? "DUPLICATE" : "OBSOLETE";
-                                // @ts-ignore
-                                window.go.main.App.Log("WARN", `[${status}] ${p.fileName} (${p.filePath}) -> ${p.obsoletedBy}`);
-                            }
+                    for (const p of toDiscover) {
+                        const norm = p.filePath.replace(/\\/g, '/').toLowerCase();
+                        if (!knownPathsRef.current.has(norm)) {
+                            knownPathsRef.current.add(norm);
+                            const libNorm = currentScanPath.replace(/\\/g, '/').toLowerCase();
+                            if (!norm.includes(libNorm)) continue;
+                            map.set(p.filePath, { ...p, isEnabled: p.filePath.endsWith('.var'), scanPhase: 'discovered' });
+                        }
+                    }
+
+                    for (const p of toScan) {
+                        const existing = map.get(p.filePath);
+                        map.set(p.filePath, {
+                            ...(existing ?? p),
+                            ...p,
+                            isEnabled: p.filePath.endsWith('.var'),
+                            scanPhase: 'scanned',
                         });
                     }
 
-                    setTimeout(() => {
-                        const tags = new Set<string>();
-                        analyzed.forEach(p => p.tags?.forEach(t => tags.add(t)));
-                        setAvailableTags(Array.from(tags).sort());
-                    }, 0);
-                    return analyzed;
+                    return Array.from(map.values());
+                });
+            };
+
+            // Phase 1 — Light Pass
+            // @ts-ignore
+            window.runtime.EventsOn('package:discovered', (data: VarPackage) => {
+                if (scanSessionId.current !== currentId) return;
+                discoveredBuffer.push(data);
+                const now = Date.now();
+                if (now - lastFlush > 200) scheduleFlush(true);
+                else scheduleFlush();
+            });
+
+            // Phase 2 — Hard Pass
+            // @ts-ignore
+            window.runtime.EventsOn('package:scanned', (data: VarPackage) => {
+                if (scanSessionId.current !== currentId) return;
+                scannedBuffer.push(data);
+                const now = Date.now();
+                if (now - lastFlush > 200) scheduleFlush(true);
+                else scheduleFlush();
+            });
+
+            // Phase 3 — Link Pass: ONE batch event with ALL analysis results.
+            // The backend emits a single 'scan:analysis:complete' event after LinkPass().
+            // We do ONE setPackages call using a Map for O(N) lookup — no O(N²).
+            // @ts-ignore
+            window.runtime.EventsOn('scan:analysis:complete', (analyses: PackageAnalysis[]) => {
+                if (scanSessionId.current !== currentId) return;
+                const byPath = new Map(analyses.map(a => [a.filePath, a]));
+                setPackages(prev => prev.map(p => {
+                    const a = byPath.get(p.filePath);
+                    if (!a) return p;
+                    return {
+                        ...p,
+                        missingDeps: a.missingDeps ?? [],
+                        isDuplicate: a.isDuplicate,
+                        isExactDuplicate: a.isExactDuplicate,
+                        isOrphan: a.isOrphan,
+                        obsoletedBy: a.obsoletedBy,
+                        referencedBy: a.referencedBy,
+                        scanPhase: 'analyzed' as const,
+                    };
+                }));
+            });
+
+            // Stage progress → update the stacked progress bar
+            // @ts-ignore
+            window.runtime.EventsOn('scan:stage', (sp: ScanStageProgress) => {
+                if (scanSessionId.current !== currentId) return;
+                setScanStages(prev => ({
+                    ...prev,
+                    [sp.stage]: { current: sp.current, total: sp.total, done: sp.done },
+                }));
+            });
+
+            // Scan complete
+            // @ts-ignore
+            window.runtime.EventsOn('scan:complete', () => {
+                if (scanSessionId.current !== currentId) return;
+                if (flushTimer) clearTimeout(flushTimer);
+                batchFlush();
+
+                // Build available tags from final package list
+                setPackages(prev => {
+                    const tags = new Set<string>();
+                    prev.forEach(p => p.tags?.forEach(t => tags.add(t)));
+                    setTimeout(() => setAvailableTags(Array.from(tags).sort()), 0);
+                    return prev;
                 });
                 setLoading(false);
             });
+
             // @ts-ignore
-            window.runtime.EventsOn("scan:error", (err: string) => {
+            window.runtime.EventsOn('scan:error', (err: string) => {
                 if (scanSessionId.current !== currentId) return;
-                if (err && err.includes("canceled")) return;
-                console.error("Scan error:", err);
+                if (err?.includes('canceled')) return;
                 setScanError(err);
                 setLoading(false);
             });
         }
 
-        // Trigger Scan
+        // Trigger scan on backend
         if (window.go) {
             try {
                 await window.go.main.App.ScanPackages(activeLibraryPath);
             } catch (e: any) {
-                console.error(e);
                 setScanError(e.message || String(e));
                 setLoading(false);
             }
         } else {
-            // Web Mode logic
+            // Web (server) mode — SSE/REST fallback
             if (scanAbortController.current) scanAbortController.current.abort();
             const controller = new AbortController();
             scanAbortController.current = controller;
-
             try {
-                // Fire and forget fetch? No, we await it to catch initial errors.
-                // But the events drive the UI.
-                const res = await fetchWithAuth(`/api/packages?path=${encodeURIComponent(activeLibraryPath)}&_t=${Date.now()}`, {
-                    signal: controller.signal
-                });
-                if (!res.ok) throw new Error("Failed to fetch");
-
-                // We typically get the full list at the end of fetch too.
-                // If we rely on events, we might duplicate?
-                // The 'uniqueBatch' check in flushBuffer prevents duplicates.
-                // The 'scan:complete' event handles finalization.
-                // We should probably IGNORE the fetch body if events are working, 
-                // OR use it as a verification/fallback.
-                // For now, let's just let the Events handle it to be consistent with Desktop.
-                // We just await the REQUEST initiation.
-                // Actually, fetch waits for Handler to finish. 
-                // The Handler finishes when Scan finishes.
-                // So this await blocks until 100%.
-                // But we get events during the wait!
-
-                // Optional: sync at end
-                // const pkgs = await res.json();
-                // setPackages(prev => ... merge ...);
-
+                await fetchWithAuth(
+                    `/api/packages?path=${encodeURIComponent(activeLibraryPath)}&_t=${Date.now()}`,
+                    { signal: controller.signal }
+                );
             } catch (e: any) {
                 if (e.name !== 'AbortError') {
-                    console.error(e);
                     setLoading(false);
                 }
             }
         }
-    }, [activeLibraryPath, analyzePackages, cancelScan]); // Added cancelScan dependency
+    }, [activeLibraryPath, cancelScan]);
 
-
-
-    // Cleanup on unmount
+    // Cleanup listeners on unmount
     useEffect(() => {
         return () => {
             if (scanAbortController.current) scanAbortController.current.abort();
-            if (window.go) {
-                window.runtime.EventsOff("package:scanned");
-                window.runtime.EventsOff("scan:progress");
-                window.runtime.EventsOff("scan:complete");
+            if (window.runtime) {
+                window.runtime.EventsOff('package:discovered');
+                window.runtime.EventsOff('package:scanned');
+                window.runtime.EventsOff('scan:analysis:complete');
+                window.runtime.EventsOff('scan:stage');
+                window.runtime.EventsOff('scan:complete');
+                window.runtime.EventsOff('scan:error');
             }
         };
     }, []);
 
+    // Creator / type status badges for sidebar (unchanged logic, minus the frontend analyzePackages)
     const { creatorStatus, typeStatus } = useMemo(() => {
         const cStatus: Record<string, 'normal' | 'warning' | 'error'> = {};
         const tStatus: Record<string, 'normal' | 'warning' | 'error'> = {};
-        const updateStatus = (map: Record<string, 'normal' | 'warning' | 'error'>, key: string, pkgStatus: 'normal' | 'warning' | 'error') => {
-            const current = map[key] || 'normal';
-            if (pkgStatus === 'error') map[key] = 'error';
-            else if (pkgStatus === 'warning' && current !== 'error') map[key] = 'warning';
+        const update = (map: Record<string, 'normal' | 'warning' | 'error'>, key: string, val: 'normal' | 'warning' | 'error') => {
+            if (val === 'error') map[key] = 'error';
+            else if (val === 'warning' && map[key] !== 'error') map[key] = 'warning';
             else if (!map[key]) map[key] = 'normal';
         };
 
         packages.forEach(p => {
             let status: 'normal' | 'warning' | 'error' = 'normal';
             if (p.isEnabled) {
-                if (p.missingDeps && p.missingDeps.length > 0) status = 'error';
-                else if (p.isDuplicate) status = 'warning'; // Note: isDuplicate is "Obsolete" here
+                if (p.missingDeps?.length) status = 'error';
+                else if (p.isDuplicate) status = 'warning';
             }
-            if (p.meta.creator) updateStatus(cStatus, p.meta.creator, status);
-            else updateStatus(cStatus, "Unknown", status);
-
-            if (p.categories && p.categories.length > 0) {
-                p.categories.forEach(c => updateStatus(tStatus, c, status));
-            } else {
-                updateStatus(tStatus, "Unknown", status);
-            }
+            update(cStatus, p.meta?.creator || 'Unknown', status);
+            (p.categories?.length ? p.categories : ['Other']).forEach(c => update(tStatus, c, status));
         });
+
         return { creatorStatus: cStatus, typeStatus: tStatus };
     }, [packages]);
 
     return {
         packages,
         setPackages,
-        scanError, // Expose Error
+        scanError,
         filteredPkgs,
         setFilteredPkgs,
         availableTags,
-        setAvailableTags, // Exposed for Tag search logic if needed
+        setAvailableTags,
         loading,
         setLoading,
-        scanProgress,
-        setScanProgress,
+        scanStages,
+        setScanStages,
         scanPackages,
         cancelScan,
+        prioritizePackages,
+        prioritizePackage,
         creatorStatus,
         typeStatus,
-        analyzePackages,
-        isCancelling
+        isCancelling,
+        // Legacy alias so existing consumers keep working while we migrate
+        scanProgress: {
+            current: scanStages.scanning.current,
+            total: scanStages.scanning.total,
+        },
     };
 };

--- a/frontend/src/hooks/usePrivacySettings.ts
+++ b/frontend/src/hooks/usePrivacySettings.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { useKeybindSubscription } from '../context/KeybindContext';
 
 export interface PrivacySettings {
@@ -13,7 +13,8 @@ export interface PrivacySettings {
 }
 
 export const usePrivacySettings = (): PrivacySettings => {
-    // -- State Initialization (Lazy Load from localStorage) --
+    // localStorage is a fast, synchronous cache that prevents the settings
+    // from appearing as "off" during the async backend config load.
     const [censorThumbnails, setCensorThumbnails] = useState(() => {
         return localStorage.getItem('privacy_censorThumbnails') === 'true';
     });
@@ -28,28 +29,55 @@ export const usePrivacySettings = (): PrivacySettings => {
         return localStorage.getItem('privacy_hideCreatorNames') === 'true';
     });
 
-    // -- Persistence Effects --
+    // Guards the persistence effect from firing before the backend config is
+    // loaded. Without this, the effect fires on mount with stale localStorage
+    // defaults and overwrites config.json before we've even read it.
+    const configLoadedRef = useRef(false);
+
+    // -- Backend Sync on Mount (Source of Truth) --
+    // MUST be defined BEFORE the persistence effect so React runs it first.
     useEffect(() => {
+        // @ts-ignore
+        if (window.go?.main?.App?.GetConfig) {
+            // @ts-ignore
+            window.go.main.App.GetConfig().then((cfg: any) => {
+                // config.json is the authoritative source; override localStorage defaults.
+                const censor = cfg.censorThumbnails ?? cfg.privacyMode ?? false;
+                setCensorThumbnails(censor);
+                if (cfg.blurAmount !== undefined) setBlurAmount(cfg.blurAmount);
+                if (cfg.hidePackageNames !== undefined) setHidePackageNames(cfg.hidePackageNames);
+                if (cfg.hideCreatorNames !== undefined) setHideCreatorNames(cfg.hideCreatorNames);
+            }).catch(() => {}).finally(() => {
+                // Allow the persistence effect to save future user-triggered changes.
+                configLoadedRef.current = true;
+            });
+        } else {
+            // Web mode — localStorage is the only source.
+            configLoadedRef.current = true;
+        }
+    }, []);
+
+    // -- Persistence (fires when user changes a setting) --
+    useEffect(() => {
+        // Skip the on-mount fire that happens before the backend config is loaded.
+        // This prevents stale localStorage values from overwriting config.json.
+        if (!configLoadedRef.current) return;
+
         localStorage.setItem('privacy_censorThumbnails', String(censorThumbnails));
-    }, [censorThumbnails]);
-
-    useEffect(() => {
         localStorage.setItem('privacy_blurAmount', String(blurAmount));
-    }, [blurAmount]);
-
-    useEffect(() => {
         localStorage.setItem('privacy_hidePackageNames', String(hidePackageNames));
-    }, [hidePackageNames]);
-
-    useEffect(() => {
         localStorage.setItem('privacy_hideCreatorNames', String(hideCreatorNames));
-    }, [hideCreatorNames]);
+
+        // @ts-ignore
+        if (window.go?.main?.App?.SetPrivacyOptions) {
+            // @ts-ignore
+            window.go.main.App.SetPrivacyOptions(censorThumbnails, blurAmount, hidePackageNames, hideCreatorNames)
+                .catch(() => {});
+        }
+    }, [censorThumbnails, blurAmount, hidePackageNames, hideCreatorNames]);
 
     // -- Keybinds --
     useKeybindSubscription('toggle_privacy', () => {
-        // Toggle all privacy settings? Or just a specific one? 
-        // Usually toggles "Hide Everything" or reverts. 
-        // Let's assume it flips Censor Thumbnails for now as primary.
         setCensorThumbnails(prev => !prev);
     }, [setCensorThumbnails]);
 

--- a/frontend/src/hooks/useServer.ts
+++ b/frontend/src/hooks/useServer.ts
@@ -26,9 +26,6 @@ export const useServer = () => {
                     setServerPort(cfg.serverPort);
                     setPublicAccess(cfg.publicAccess);
                     setAuthPollInterval(cfg.authPollInterval);
-                    // LocalIP is usually fetched separately via GetLocalIP but context initialized it to "Loading..."
-                    // Let's grab IP too if possible or separate call? 
-                    // Dashboard used to call GetLocalIP() separately. Let's add that too.
                     // @ts-ignore
                     window.go.main.App.GetLocalIP().then((ip: string) => setLocalIP(ip));
                 }
@@ -38,6 +35,10 @@ export const useServer = () => {
 
     // -- Actions --
 
+    /**
+     * Toggles the "Run on Startup" config flag.
+     * This only persists the preference; it does NOT start/stop the live server process.
+     */
     const toggleServer = async (addToast: (msg: string, type: ToastType) => void) => {
         if (isTogglingServer) return;
         setIsTogglingServer(true);
@@ -53,6 +54,41 @@ export const useServer = () => {
                 addToast("Failed to toggle server: " + e, 'error');
             } finally {
                 setIsTogglingServer(false);
+            }
+        }
+    };
+
+    /**
+     * Starts the live HTTP server process immediately.
+     * This is separate from the "Run on Startup" preference.
+     */
+    const startServer = async (addToast: (msg: string, type: ToastType) => void) => {
+        // @ts-ignore
+        if (window.go?.main?.App) {
+            try {
+                // @ts-ignore
+                await window.go.main.App.StartServer();
+                // Backend emits "server:status:changed" → NetworkTab polls IsServerRunning()
+                addToast('Server started', 'success');
+            } catch (e: any) {
+                addToast('Failed to start server: ' + e, 'error');
+            }
+        }
+    };
+
+    /**
+     * Stops the live HTTP server process immediately.
+     * This is separate from the "Run on Startup" preference.
+     */
+    const stopServer = async (addToast: (msg: string, type: ToastType) => void) => {
+        // @ts-ignore
+        if (window.go?.main?.App) {
+            try {
+                // @ts-ignore
+                await window.go.main.App.StopServer();
+                addToast('Server stopped', 'info');
+            } catch (e: any) {
+                addToast('Failed to stop server: ' + e, 'error');
             }
         }
     };
@@ -112,7 +148,9 @@ export const useServer = () => {
 
         // Actions
         toggleServer,
+        startServer,
+        stopServer,
         togglePublicAccess,
-        updateAuthPollInterval
+        updateAuthPollInterval,
     };
 };

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1,3 +1,5 @@
+export type ScanPhase = 'discovered' | 'scanned' | 'analyzed';
+
 export interface VarPackage {
     filePath: string;
     fileName: string;
@@ -22,5 +24,32 @@ export interface VarPackage {
     isCorrupt?: boolean;
     isOrphan?: boolean;
     referencedBy?: string[];
-    obsoletedBy?: string; // Diagnostic info: "vX.Y (filename)"
+    obsoletedBy?: string;
+    /** Tracks how much we know about this package from the three-phase scan. */
+    scanPhase: ScanPhase;
+}
+
+/** Payload of the "package:analyzed" event — dep/dup/orphan flags per package. */
+export interface PackageAnalysis {
+    filePath: string;
+    missingDeps: string[];
+    isDuplicate: boolean;
+    isExactDuplicate: boolean;
+    isOrphan: boolean;
+    obsoletedBy?: string;
+    referencedBy?: string[];
+}
+
+/** Payload of the "scan:stage" event — progress across all three phases. */
+export interface ScanStageProgress {
+    stage: 'discovery' | 'scanning' | 'analyzing';
+    current: number;
+    total: number;
+    done: boolean;
+}
+
+export interface ScanStages {
+    discovery: { current: number; total: number; done: boolean };
+    scanning:  { current: number; total: number; done: boolean };
+    analyzing: { current: number; total: number; done: boolean };
 }

--- a/frontend/src/wailsjs/go/main/App.d.ts
+++ b/frontend/src/wailsjs/go/main/App.d.ts
@@ -18,6 +18,8 @@ export function CheckForUpdates():Promise<updater.UpdateInfo>;
 
 export function ClearAppData():Promise<void>;
 
+export function ClearThumbnailCache():Promise<void>;
+
 export function CopyFileToClipboard(arg1:string):Promise<void>;
 
 export function CopyPackagesToLibrary(arg1:Array<string>,arg2:string,arg3:boolean):Promise<Array<string>>;
@@ -56,6 +58,8 @@ export function GetPackageContents(arg1:string):Promise<Array<models.PackageCont
 
 export function GetPackageThumbnail(arg1:string):Promise<string>;
 
+export function GetThumbnailCacheSize():Promise<number>;
+
 export function GetUserDownloadsDir():Promise<string>;
 
 export function Greet(arg1:string):Promise<string>;
@@ -78,6 +82,8 @@ export function OpenAppDataFolder():Promise<void>;
 
 export function OpenFolderInExplorer(arg1:string):Promise<void>;
 
+export function PrioritizePackage(arg1:string):Promise<void>;
+
 export function RemoveConfiguredLibrary(arg1:string):Promise<void>;
 
 export function ReorderConfiguredLibraries(arg1:Array<string>):Promise<void>;
@@ -97,6 +103,8 @@ export function SelectDirectory():Promise<string>;
 export function SetAlwaysOnTop(arg1:boolean):Promise<void>;
 
 export function SetAuthPollInterval(arg1:number):Promise<void>;
+
+export function SetCurrentPage(arg1:Array<string>):Promise<void>;
 
 export function SetGridSize(arg1:number):Promise<void>;
 

--- a/frontend/src/wailsjs/go/main/App.js
+++ b/frontend/src/wailsjs/go/main/App.js
@@ -26,6 +26,10 @@ export function ClearAppData() {
   return window['go']['main']['App']['ClearAppData']();
 }
 
+export function ClearThumbnailCache() {
+  return window['go']['main']['App']['ClearThumbnailCache']();
+}
+
 export function CopyFileToClipboard(arg1) {
   return window['go']['main']['App']['CopyFileToClipboard'](arg1);
 }
@@ -102,6 +106,10 @@ export function GetPackageThumbnail(arg1) {
   return window['go']['main']['App']['GetPackageThumbnail'](arg1);
 }
 
+export function GetThumbnailCacheSize() {
+  return window['go']['main']['App']['GetThumbnailCacheSize']();
+}
+
 export function GetUserDownloadsDir() {
   return window['go']['main']['App']['GetUserDownloadsDir']();
 }
@@ -146,6 +154,10 @@ export function OpenFolderInExplorer(arg1) {
   return window['go']['main']['App']['OpenFolderInExplorer'](arg1);
 }
 
+export function PrioritizePackage(arg1) {
+  return window['go']['main']['App']['PrioritizePackage'](arg1);
+}
+
 export function RemoveConfiguredLibrary(arg1) {
   return window['go']['main']['App']['RemoveConfiguredLibrary'](arg1);
 }
@@ -184,6 +196,10 @@ export function SetAlwaysOnTop(arg1) {
 
 export function SetAuthPollInterval(arg1) {
   return window['go']['main']['App']['SetAuthPollInterval'](arg1);
+}
+
+export function SetCurrentPage(arg1) {
+  return window['go']['main']['App']['SetCurrentPage'](arg1);
 }
 
 export function SetGridSize(arg1) {

--- a/pkg/cache/thumbnail_cache.go
+++ b/pkg/cache/thumbnail_cache.go
@@ -1,0 +1,92 @@
+package cache
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// ThumbnailCache is a content-addressed, disk-backed cache for package cover thumbnails.
+//
+// Key design choices:
+//   - Only package-level thumbnails are cached (not per-content thumbnails from the RightSidebar).
+//     This keeps storage predictable: typically 50–300 KB per package.
+//   - The cache key encodes file path, modification time, and file size so that any change to the
+//     .var file (rename, update) automatically invalidates its entry — no manual expiry needed.
+//   - Files are stored flat in the cache directory as "<sha256hex>.jpg" (JPEG regardless of source
+//     format — thumbnails from VaM are always JPEG in practice).
+type ThumbnailCache struct {
+	dir string
+}
+
+// NewThumbnailCache creates a cache rooted at dir (created if absent).
+func NewThumbnailCache(dir string) (*ThumbnailCache, error) {
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return nil, fmt.Errorf("thumbnail cache: mkdir %s: %w", dir, err)
+	}
+	return &ThumbnailCache{dir: dir}, nil
+}
+
+// cacheKey returns the hex-encoded SHA-256 of the compound identity string.
+func (c *ThumbnailCache) cacheKey(pkgPath string, modTime time.Time, size int64) string {
+	raw := fmt.Sprintf("%s|%d|%d", pkgPath, modTime.UnixNano(), size)
+	sum := sha256.Sum256([]byte(raw))
+	return fmt.Sprintf("%x", sum)
+}
+
+func (c *ThumbnailCache) cachePath(key string) string {
+	return filepath.Join(c.dir, key+".jpg")
+}
+
+// Get returns cached thumbnail bytes for the given package identity, or (nil, false) on a miss.
+func (c *ThumbnailCache) Get(pkgPath string, modTime time.Time, size int64) ([]byte, bool) {
+	key := c.cacheKey(pkgPath, modTime, size)
+	data, err := os.ReadFile(c.cachePath(key))
+	if err != nil {
+		return nil, false
+	}
+	return data, true
+}
+
+// Set writes thumbnail bytes to disk for the given package identity.
+// Errors are non-fatal — a cache write failure just means the next scan will re-parse the zip.
+func (c *ThumbnailCache) Set(pkgPath string, modTime time.Time, size int64, data []byte) error {
+	key := c.cacheKey(pkgPath, modTime, size)
+	return os.WriteFile(c.cachePath(key), data, 0644)
+}
+
+// Clear removes every file in the cache directory.
+func (c *ThumbnailCache) Clear() error {
+	entries, err := os.ReadDir(c.dir)
+	if err != nil {
+		return fmt.Errorf("thumbnail cache: readdir: %w", err)
+	}
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		_ = os.Remove(filepath.Join(c.dir, e.Name()))
+	}
+	return nil
+}
+
+// Size returns the total byte size of all files currently in the cache.
+func (c *ThumbnailCache) Size() (int64, error) {
+	entries, err := os.ReadDir(c.dir)
+	if err != nil {
+		return 0, fmt.Errorf("thumbnail cache: readdir: %w", err)
+	}
+	var total int64
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		info, err := e.Info()
+		if err == nil {
+			total += info.Size()
+		}
+	}
+	return total, nil
+}

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -68,10 +68,34 @@ func NewManager(sys system.SystemService, lib library.LibraryService, cfg config
 	return m
 }
 
-// ScanAndAnalyze delegates to LibraryService
+// ScanAndAnalyze delegates to LibraryService (legacy)
 func (m *Manager) ScanAndAnalyze(ctx context.Context, rootPath string, onPackage func(models.VarPackage), onProgress func(int, int)) error {
 	return m.library.Scan(ctx, rootPath, onPackage, onProgress)
 }
+
+// ScanFull runs the three-phase scan and delegates to LibraryService.
+func (m *Manager) ScanFull(
+	ctx context.Context,
+	rootPath string,
+	onDiscovered func(models.VarPackage),
+	onScanned func(models.VarPackage),
+	onAnalysisDone func([]library.PackageAnalysis),
+	onStage func(library.ScanStageProgress),
+) error {
+	return m.library.ScanFull(ctx, rootPath, onDiscovered, onScanned, onAnalysisDone, onStage)
+}
+
+// Prioritize bumps the given paths to the front of the Hard Pass queue.
+func (m *Manager) Prioritize(paths []string) { m.library.Prioritize(paths) }
+
+// SetCurrentPage notifies the scan engine that the given paths are on the current page.
+func (m *Manager) SetCurrentPage(paths []string) { m.library.SetCurrentPage(paths) }
+
+// ClearThumbnailCache removes all cached thumbnail files.
+func (m *Manager) ClearThumbnailCache() error { return m.library.ClearThumbnailCache() }
+
+// ThumbnailCacheSize returns the total byte size of the thumbnail cache.
+func (m *Manager) ThumbnailCacheSize() (int64, error) { return m.library.ThumbnailCacheSize() }
 
 // GetPackageContents delegates to LibraryService
 func (m *Manager) GetPackageContents(pkgPath string) ([]models.PackageContent, error) {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -16,6 +16,7 @@ import (
 	"yavam/pkg/models"
 	"yavam/pkg/services/auth"
 	"yavam/pkg/services/config"
+	"yavam/pkg/services/library"
 	"yavam/pkg/updater"
 
 	"github.com/wailsapp/wails/v2/pkg/runtime"
@@ -415,17 +416,27 @@ func (s *Server) Start(port string, libraries []string) error {
 		defer s.scanWg.Done()
 
 		var pkgs []models.VarPackage
-		err := s.manager.ScanAndAnalyze(ctx, targetPath, func(p models.VarPackage) {
-			pkgs = append(pkgs, p)
-			// Broadcast package to web clients (incremental update)
-			s.Broadcast("package:scanned", p)
-		}, func(current, total int) {
-			// Broadcast progress to web clients
-			s.Broadcast("scan:progress", map[string]interface{}{
-				"current": current,
-				"total":   total,
-			})
-		})
+		err := s.manager.ScanFull(
+			ctx,
+			targetPath,
+			// Phase 1 — Light Pass: file discovered
+			func(pkg models.VarPackage) {
+				pkgs = append(pkgs, pkg)
+				s.Broadcast("package:discovered", pkg)
+			},
+			// Phase 2 — Hard Pass: full metadata
+			func(pkg models.VarPackage) {
+				s.Broadcast("package:scanned", pkg)
+			},
+			// Phase 3 — Link Pass: batch analysis
+			func(analyses []library.PackageAnalysis) {
+				s.Broadcast("scan:analysis:complete", analyses)
+			},
+			// Stage progress
+			func(sp library.ScanStageProgress) {
+				s.Broadcast("scan:stage", sp)
+			},
+		)
 		if err != nil {
 			s.Broadcast("scan:error", err.Error())
 			s.writeError(w, err.Error(), 500)

--- a/pkg/services/library/analysis.go
+++ b/pkg/services/library/analysis.go
@@ -8,91 +8,293 @@ import (
 	"yavam/pkg/models"
 )
 
-// ResolveConflictResult holds statistics about the resolution operation
-// Note: This struct is defined in models, but duplicated in manager.go originally. Used models one.
+// PackageAnalysis holds the analysis results for a single package from the Link Pass.
+// This struct is emitted as the "package:analyzed" event payload.
+type PackageAnalysis struct {
+	FilePath        string   `json:"filePath"`
+	MissingDeps     []string `json:"missingDeps"`
+	IsDuplicate     bool     `json:"isDuplicate"`     // Obsoleted by a newer version
+	IsExactDuplicate bool    `json:"isExactDuplicate"` // Identical copy (same version + size)
+	IsOrphan        bool     `json:"isOrphan"`        // Not referenced by any enabled package
+	ObsoletedBy     string   `json:"obsoletedBy,omitempty"`
+	ReferencedBy    []string `json:"referencedBy,omitempty"`
+}
 
-// CheckDependencies analyzes packages for missing dependencies
-func (s *defaultLibraryService) CheckDependencies(pkgs []models.VarPackage) []models.VarPackage {
-	// Build an index of available package IDs "Creator.Package.Version"
-	// And "Creator.Package" (latest)
-	available := make(map[string]bool)
-
-	for _, p := range pkgs {
-		// strict ID
-		id := fmt.Sprintf("%s.%s.%s", p.Meta.Creator, p.Meta.PackageName, p.Meta.Version)
-		available[strings.ToLower(id)] = true
-
-		// loose ID (just package existence)
-		baseId := fmt.Sprintf("%s.%s", p.Meta.Creator, p.Meta.PackageName)
-		available[strings.ToLower(baseId)] = true
+// LinkPass runs full dependency, duplicate and orphan analysis over all scanned packages.
+//
+// resolvers are tried in order for dependency resolution; the first one that resolves a dep wins.
+// Pass a LocalResolver as the first argument. Future callers may append a MultiLibraryResolver or
+// OnlineResolver — no changes to this function are needed.
+//
+// This function is intentionally pure: it takes a slice and returns analysis results without
+// mutating the input packages. The caller (scan_orchestrator) applies them back.
+func LinkPass(pkgs []models.VarPackage, resolvers ...DependencyResolver) []PackageAnalysis {
+	if len(pkgs) == 0 {
+		return nil
 	}
 
-	for i := range pkgs {
-		var missing []string
-		if pkgs[i].Meta.Dependencies != nil {
-			for depID := range pkgs[i].Meta.Dependencies {
-				// Dependency format in meta.json is "Creator.Package.Version" : "license/url"
-				// We check if "Creator.Package.Version" exists
-				// VaM also allows "latest" typically handled by game, but meta lists specific version.
+	// ── Build ID sets for dependency resolution ──────────────────────────────
+	// Collect all package IDs once; resolvers use these internally.
+	// (LocalResolver is already built — this step is for orphan/duplicate detection.)
 
-				depIDLower := strings.ToLower(depID)
+	// ── Group packages by "Creator.PackageName" for duplicate detection ──────
+	type group struct {
+		pkgs []models.VarPackage
+	}
+	groups := make(map[string]*group)
+	for _, p := range pkgs {
+		if p.IsCorrupt {
+			continue
+		}
+		key := strings.ToLower(p.Meta.Creator + "." + p.Meta.PackageName)
+		if _, ok := groups[key]; !ok {
+			groups[key] = &group{}
+		}
+		groups[key].pkgs = append(groups[key].pkgs, p)
+	}
 
-				// Check strict existence
-				if !available[depIDLower] {
-					// Check if any version of that package exists?
-					// Technically missing specific version might be fine if a newer one exists,
-					// but strictly it's missing.
-					// Let's check if the base package exists at least.
-					parts := strings.Split(depIDLower, ".")
-					if len(parts) >= 2 {
-						baseId := fmt.Sprintf("%s.%s", parts[0], parts[1])
-						if !available[baseId] {
-							missing = append(missing, depID)
-						}
-					} else {
-						missing = append(missing, depID)
+	obsoletePaths := make(map[string]string) // filePath → reason
+	redundantPaths := make(map[string]string)
+
+	compareVersions := func(v1, v2 string) int {
+		if v1 == v2 {
+			return 0
+		}
+		p1 := strings.Split(v1, ".")
+		p2 := strings.Split(v2, ".")
+		l := len(p1)
+		if len(p2) > l {
+			l = len(p2)
+		}
+		for i := 0; i < l; i++ {
+			var n1, n2 int
+			if i < len(p1) {
+				fmt.Sscanf(p1[i], "%d", &n1)
+			}
+			if i < len(p2) {
+				fmt.Sscanf(p2[i], "%d", &n2)
+			}
+			if n1 > n2 {
+				return 1
+			}
+			if n1 < n2 {
+				return -1
+			}
+		}
+		return 0
+	}
+
+	for _, g := range groups {
+		if len(g.pkgs) <= 1 {
+			continue
+		}
+		// Sort: enabled first, then descending version
+		sorted := make([]models.VarPackage, len(g.pkgs))
+		copy(sorted, g.pkgs)
+		for i := 0; i < len(sorted); i++ {
+			for j := i + 1; j < len(sorted); j++ {
+				a, b := sorted[i], sorted[j]
+				swap := false
+				if !a.IsEnabled && b.IsEnabled {
+					swap = true
+				} else if a.IsEnabled == b.IsEnabled {
+					if compareVersions(b.Meta.Version, a.Meta.Version) > 0 {
+						swap = true
 					}
+				}
+				if swap {
+					sorted[i], sorted[j] = sorted[j], sorted[i]
 				}
 			}
 		}
-		pkgs[i].MissingDeps = missing
+		head := sorted[0]
+		for _, other := range sorted[1:] {
+			cmp := compareVersions(other.Meta.Version, head.Meta.Version)
+			if cmp == 0 {
+				redundantPaths[other.FilePath] = fmt.Sprintf("Identical copy of %s", head.FilePath)
+			} else {
+				obsoletePaths[other.FilePath] = fmt.Sprintf("Obsoleted by v%s (%s)", head.Meta.Version, head.FileName)
+			}
+		}
+	}
+
+	// ── Exact duplicate detection (same version + same size) ─────────────────
+	exactKey := func(p models.VarPackage) string {
+		return strings.ToLower(fmt.Sprintf("%s.%s.%s|%d", p.Meta.Creator, p.Meta.PackageName, p.Meta.Version, p.Size))
+	}
+	exactCounts := make(map[string]int)
+	for _, p := range pkgs {
+		if !p.IsCorrupt {
+			exactCounts[exactKey(p)]++
+		}
+	}
+
+	// ── Orphan / reverse-dependency graph ────────────────────────────────────
+	// An orphan is an enabled, non-corrupt package that is not referenced by any
+	// other enabled package's dependency list.
+	reverseDeps := make(map[string][]string) // pkgID → [referencedBy IDs]
+	pkgIDSet := make(map[string]bool)
+	for _, p := range pkgs {
+		if p.IsCorrupt || p.Meta.Creator == "" {
+			continue
+		}
+		id := strings.ToLower(fmt.Sprintf("%s.%s.%s", p.Meta.Creator, p.Meta.PackageName, p.Meta.Version))
+		pkgIDSet[id] = true
+	}
+	for _, p := range pkgs {
+		if p.IsCorrupt || !p.IsEnabled {
+			continue
+		}
+		myID := strings.ToLower(fmt.Sprintf("%s.%s.%s", p.Meta.Creator, p.Meta.PackageName, p.Meta.Version))
+		for depID := range p.Meta.Dependencies {
+			dLower := strings.ToLower(depID)
+			reverseDeps[dLower] = append(reverseDeps[dLower], myID)
+		}
+	}
+	referenced := make(map[string]bool)
+	for depID := range reverseDeps {
+		referenced[depID] = true
+	}
+
+	// ── Assemble results ──────────────────────────────────────────────────────
+	results := make([]PackageAnalysis, 0, len(pkgs))
+
+	// Build a set of enabled base IDs for dependency resolution
+	enabledBase := make(map[string]bool)
+	for _, p := range pkgs {
+		if p.IsEnabled && !p.IsCorrupt && p.Meta.Creator != "" {
+			b := strings.ToLower(p.Meta.Creator + "." + p.Meta.PackageName)
+			enabledBase[b] = true
+		}
+	}
+
+	for _, p := range pkgs {
+		a := PackageAnalysis{FilePath: p.FilePath}
+
+		if ob, ok := obsoletePaths[p.FilePath]; ok {
+			a.IsDuplicate = true
+			a.ObsoletedBy = ob
+		}
+		if rd, ok := redundantPaths[p.FilePath]; ok {
+			a.IsExactDuplicate = true
+			if a.ObsoletedBy == "" {
+				a.ObsoletedBy = rd
+			}
+		}
+		if exactCounts[exactKey(p)] > 1 {
+			a.IsExactDuplicate = true
+			if a.ObsoletedBy == "" {
+				a.ObsoletedBy = "Identical copy exists in library"
+			}
+		}
+
+		// Missing dependency detection — uses supplied resolvers in order
+		if p.IsEnabled && !p.IsCorrupt && p.Meta.Dependencies != nil {
+			for depID := range p.Meta.Dependencies {
+				dLower := strings.ToLower(depID)
+
+				// Skip well-known built-in IDs
+				if dLower == "everlaster.core.latest" || strings.HasPrefix(dLower, "system.") {
+					continue
+				}
+
+				resolved := false
+				for _, r := range resolvers {
+					if r.ResolveExact(depID) || r.ResolveBase(depID) {
+						resolved = true
+						break
+					}
+					// .latest resolution
+					if strings.HasSuffix(dLower, ".latest") {
+						base := dLower[:len(dLower)-7]
+						if r.ResolveBase(base) {
+							resolved = true
+							break
+						}
+					}
+					// Recursive base lookup (handles multi-dot package names)
+					temp := dLower
+					for strings.Contains(temp, ".") {
+						last := strings.LastIndex(temp, ".")
+						temp = temp[:last]
+						if r.ResolveBase(temp) {
+							resolved = true
+							break
+						}
+					}
+					if resolved {
+						break
+					}
+				}
+
+				if !resolved {
+					a.MissingDeps = append(a.MissingDeps, depID)
+				}
+			}
+		}
+
+		// Orphan detection
+		if p.IsEnabled && !p.IsCorrupt && p.Meta.Creator != "" {
+			myID := strings.ToLower(fmt.Sprintf("%s.%s.%s", p.Meta.Creator, p.Meta.PackageName, p.Meta.Version))
+			if !referenced[myID] {
+				a.IsOrphan = true
+			}
+			if deps, ok := reverseDeps[myID]; ok {
+				a.ReferencedBy = deps
+			}
+		}
+
+		results = append(results, a)
+	}
+
+	return results
+}
+
+// ── Existing service methods (unchanged contract) ─────────────────────────────
+
+// CheckDependencies analyzes packages for missing dependencies.
+// This is preserved for backward compatibility; internally it now uses LinkPass.
+func (s *defaultLibraryService) CheckDependencies(pkgs []models.VarPackage) []models.VarPackage {
+	resolver := NewLocalResolver(pkgs)
+	analyses := LinkPass(pkgs, resolver)
+	byPath := make(map[string]PackageAnalysis, len(analyses))
+	for _, a := range analyses {
+		byPath[a.FilePath] = a
+	}
+	for i := range pkgs {
+		if a, ok := byPath[pkgs[i].FilePath]; ok {
+			pkgs[i].MissingDeps = a.MissingDeps
+		}
 	}
 	return pkgs
 }
 
 // ResolveConflicts handles deduplication and cleanup of conflicting packages
 func (s *defaultLibraryService) ResolveConflicts(keepPath string, others []string, libraryPath string) (*models.ResolveConflictResult, error) {
-	// 1. Get info of the file to keep
 	keepInfo, err := os.Stat(keepPath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to stat keep file: %v", err)
 	}
 
 	result := &models.ResolveConflictResult{
-		Merged:   0,
+		Merged:  0,
 		Disabled: 0,
-		NewPath:  keepPath,
+		NewPath: keepPath,
 	}
 
-	// 2. Process conflicting files
 	for _, otherPath := range others {
 		if otherPath == keepPath {
 			continue
 		}
-
 		otherInfo, err := os.Stat(otherPath)
 		if os.IsNotExist(err) {
-			continue // Already gone
+			continue
 		}
-
-		// Merge Check: Exactly same size?
 		if otherInfo.Size() == keepInfo.Size() {
-			// MATCH! Deleting duplicate
 			if err := os.Remove(otherPath); err == nil {
 				result.Merged++
 			}
 		} else {
-			// MISMATCH! Disabling
 			if !strings.HasSuffix(otherPath, ".disabled") {
 				disabledPath := otherPath + ".disabled"
 				if err := os.Rename(otherPath, disabledPath); err == nil {
@@ -102,38 +304,22 @@ func (s *defaultLibraryService) ResolveConflicts(keepPath string, others []strin
 		}
 	}
 
-	// 3. Move 'keepPath' to Library Root (Standardization)
-	// Only if it's not already in the root
 	baseName := filepath.Base(keepPath)
 	targetPath := filepath.Join(libraryPath, baseName)
 
 	if filepath.Clean(keepPath) != filepath.Clean(targetPath) {
-		// Move it
-		// Check if target exists
 		if _, err := os.Stat(targetPath); err == nil {
-			// Target exists. Is it me?
 			if filepath.Clean(keepPath) != filepath.Clean(targetPath) {
-				// We have a collision at the destination.
-				// This implies we are merging FROM a subdirectory or sidecar TO the root.
-				// If we are here, we probably should have checked this earlier.
-				// But let's check size.
 				destInfo, _ := os.Stat(targetPath)
 				if destInfo.Size() == keepInfo.Size() {
-					// Dest is same. Delete source.
 					os.Remove(keepPath)
 					result.NewPath = targetPath
 					result.Merged++
 					return result, nil
 				}
-				// Dest is different.
-				// We should probably backup dest? Or rename source?
-				// Original logic was complex here. Let's assume we overwrite if we "Keep" this one?
-				// Or fail.
 				return result, fmt.Errorf("target file already exists and is different: %s", targetPath)
 			}
 		}
-
-		// Move
 		if err := os.Rename(keepPath, targetPath); err != nil {
 			return result, err
 		}

--- a/pkg/services/library/dependency_resolver.go
+++ b/pkg/services/library/dependency_resolver.go
@@ -1,0 +1,60 @@
+package library
+
+import (
+	"strings"
+	"yavam/pkg/models"
+)
+
+// DependencyResolver resolves package dependency IDs against a known source.
+//
+// Implement this interface to support different resolution strategies:
+//
+//   - LocalResolver (below): checks packages present in the current library scan result.
+//
+//   - TODO MultiLibraryResolver: check packages across arbitrary library paths on disk.
+//     Implement ResolveExact / ResolveBase by walking additional directories and building
+//     the same index as LocalResolver, but sourced from external paths.
+//
+//   - TODO OnlineResolver: query the VaM Hub REST API for package availability.
+//     Implement ResolveExact / ResolveBase by issuing an HTTP GET to the Hub search endpoint
+//     and caching results in memory for the lifetime of the scan.
+//
+// To add a new resolver: implement this interface and pass it as an additional argument to
+// LinkPass(). Resolvers are tried in the order provided — the first one that returns true wins.
+type DependencyResolver interface {
+	// ResolveExact returns true if a package with the exact ID "Creator.Name.Version" is available.
+	ResolveExact(id string) bool
+
+	// ResolveBase returns true if any version of the package "Creator.Name" is available.
+	ResolveBase(baseID string) bool
+}
+
+// LocalResolver implements DependencyResolver using the set of packages found during the Hard Pass.
+// Build it once, after all packages have been scanned, then pass it to LinkPass.
+type LocalResolver struct {
+	exact map[string]bool // "creator.name.version" → true
+	base  map[string]bool // "creator.name"         → true
+}
+
+// NewLocalResolver builds a LocalResolver from a slice of fully-scanned packages.
+func NewLocalResolver(pkgs []models.VarPackage) *LocalResolver {
+	r := &LocalResolver{
+		exact: make(map[string]bool, len(pkgs)),
+		base:  make(map[string]bool, len(pkgs)),
+	}
+	for _, p := range pkgs {
+		if p.IsCorrupt || p.Meta.Creator == "" || p.Meta.PackageName == "" {
+			continue
+		}
+		id := strings.ToLower(p.Meta.Creator + "." + p.Meta.PackageName + "." + p.Meta.Version)
+		base := strings.ToLower(p.Meta.Creator + "." + p.Meta.PackageName)
+		r.exact[id] = true
+		r.base[base] = true
+	}
+	return r
+}
+
+func (r *LocalResolver) ResolveExact(id string) bool { return r.exact[strings.ToLower(id)] }
+func (r *LocalResolver) ResolveBase(baseID string) bool {
+	return r.base[strings.ToLower(baseID)]
+}

--- a/pkg/services/library/library.go
+++ b/pkg/services/library/library.go
@@ -1,28 +1,44 @@
 package library
 
 import (
+	"os"
+	"path/filepath"
+	"yavam/pkg/cache"
 	"yavam/pkg/fs"
 	"yavam/pkg/scanner"
 	"yavam/pkg/services/system"
 )
 
 type defaultLibraryService struct {
-	scanner *scanner.Scanner
-	system  system.SystemService
-	fs      fs.FileSystem
+	scanner    *scanner.Scanner
+	system     system.SystemService
+	fs         fs.FileSystem
+	thumbCache *cache.ThumbnailCache
 
-	// Caches?
-	// Manager didn't persist cache in memory beyond what was returned?
-	// It returned counts on demand using scanner.
+	// active holds state for the currently-running scan so priority bumps
+	// from SetCurrentPage / Prioritize can reach the orchestrator.
+	active activeScan
 }
 
+// NewLibraryService constructs a defaultLibraryService.
+// The thumbnail cache is stored in %AppData%/YAVAM/thumbnails/ and is created if absent.
 func NewLibraryService(sys system.SystemService, fileSystem fs.FileSystem) LibraryService {
 	if fileSystem == nil {
 		fileSystem = &fs.WindowsFileSystem{}
 	}
+
+	// Build thumbnail cache directory.
+	var tc *cache.ThumbnailCache
+	configDir, err := os.UserConfigDir()
+	if err == nil {
+		thumbDir := filepath.Join(configDir, "YAVAM", "thumbnails")
+		tc, _ = cache.NewThumbnailCache(thumbDir) // non-fatal if it fails
+	}
+
 	return &defaultLibraryService{
-		scanner: scanner.NewScanner(),
-		system:  sys,
-		fs:      fileSystem,
+		scanner:    scanner.NewScanner(),
+		system:     sys,
+		fs:         fileSystem,
+		thumbCache: tc,
 	}
 }

--- a/pkg/services/library/read.go
+++ b/pkg/services/library/read.go
@@ -5,10 +5,12 @@ import (
 	"encoding/base64"
 	"fmt"
 	"io"
+	"os"
 	"path/filepath"
 	"sort"
 	"strings"
 	"yavam/pkg/models"
+	"yavam/pkg/parser"
 )
 
 // GetPackageContents scans a .var file and returns a list of its displayable contents
@@ -128,13 +130,44 @@ func (s *defaultLibraryService) GetPackageContents(pkgPath string) ([]models.Pac
 	return contents, nil
 }
 
+// GetThumbnail returns the cover thumbnail bytes for a package.
+// Strategy (cache-first to avoid zip opens):
+//  1. Check the thumbnail disk cache using (path + modTime + size) as key.
+//  2. On a cache hit: return immediately — no zip open needed.
+//  3. On a cache miss: open the zip, extract the thumbnail, cache it, return.
+//
+// This is called by the frontend's lazy-load IntersectionObserver path for packages
+// whose HasThumbnail == true. Because the Hard Pass caches thumbnails as it scans,
+// most requests will hit the cache. Only the very first request for a not-yet-scanned
+// package will incur a zip open.
 func (s *defaultLibraryService) GetThumbnail(pkgPath string) ([]byte, error) {
-	// Not implemented in Manager originally?
-	// It was embedded in `ScanAndAnalyze` or `GetPackageContents`.
-	// For API, we might want it separate.
-	// Implementing basic extraction of "thumb.jpg" or similar if needed.
-	// For now, returning error/empty conforming to interface.
-	return nil, fmt.Errorf("not implemented")
+	// 1. Cache hit
+	if s.thumbCache != nil {
+		info, err := os.Stat(pkgPath)
+		if err == nil {
+			if data, ok := s.thumbCache.Get(pkgPath, info.ModTime(), info.Size()); ok {
+				return data, nil
+			}
+		}
+	}
+
+	// 2. Cache miss — open zip and extract thumbnail
+	_, thumbBytes, _, err := parser.ParseVarMetadata(pkgPath)
+	if err != nil {
+		return nil, fmt.Errorf("thumbnail: parse failed: %w", err)
+	}
+	if len(thumbBytes) == 0 {
+		return nil, fmt.Errorf("thumbnail: not found in %s", pkgPath)
+	}
+
+	// 3. Cache for next time
+	if s.thumbCache != nil {
+		if info, err := os.Stat(pkgPath); err == nil {
+			_ = s.thumbCache.Set(pkgPath, info.ModTime(), info.Size(), thumbBytes)
+		}
+	}
+
+	return thumbBytes, nil
 }
 
 func (s *defaultLibraryService) GetCounts(libraries []string) map[string]int {

--- a/pkg/services/library/scan.go
+++ b/pkg/services/library/scan.go
@@ -5,143 +5,138 @@ import (
 	"sort"
 	"strings"
 	"sync"
+	"yavam/pkg/cache"
 	"yavam/pkg/models"
-	"yavam/pkg/parser"
 )
 
-// Scan scans the directory and streams results via callbacks
+// activeScan holds state for the currently-running three-phase scan so that
+// SetCurrentPage / PrioritizePackage can inject priority bumps at any time.
+type activeScan struct {
+	mu          sync.Mutex
+	orchestrator *scanOrchestrator
+}
+
+// Scan runs the three-phase scan against rootPath, streaming results via callbacks.
+//
+// Callbacks:
+//   - onDiscovered  → called once per package during the Light Pass (no zip open)
+//   - onScanned     → called once per package when the Hard Pass finishes it
+//   - onAnalyzed    → called once per package when the Link Pass finishes
+//   - onStage       → called on every meaningful progress tick across all three phases
+//
+// The old onPackage / onProgress callbacks in the LibraryService interface are preserved
+// via the wrapper in service.go for callers that haven't migrated yet.
 func (s *defaultLibraryService) Scan(ctx context.Context, rootPath string, onPackage func(models.VarPackage), onProgress func(int, int)) error {
 	rawPkgs, err := s.scanner.ScanForPackages(rootPath)
 	if err != nil {
 		return err
 	}
 
-	total := len(rawPkgs)
-	processed := 0
-	var wg sync.WaitGroup
-	// Callback mutex to ensure sequential writes
-	var cbMu sync.Mutex
-
-	// Channels for tags/deduplication if needed?
-	// Manager filtered duplicate tags.
-	tagSet := make(map[string]bool)
-	var tagMu sync.Mutex
-
-	// Semaphore to limit concurrency
-	sem := make(chan struct{}, 20)
-
-	// Notify initial progress
-	if onProgress != nil {
-		onProgress(0, total)
-	}
-
-	for _, pkg := range rawPkgs {
-		// Check cancellation
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		default:
-		}
-
-		wg.Add(1)
-		go func(p models.VarPackage) {
-			defer wg.Done()
-
-			select {
-			case <-ctx.Done():
-				return
-			default:
-			}
-
-			sem <- struct{}{}        // Acquire
-			defer func() { <-sem }() // Release
-
-			// Double check cancellation after acquire
-			select {
-			case <-ctx.Done():
-				return
-			default:
-			}
-
-			meta, thumbBytes, categories, err := parser.ParseVarMetadata(p.FilePath)
-			if err == nil {
-				p.Meta = meta
-
-				// Sort Categories for stability and primary type selection
-				sortCategories(categories)
-				p.Categories = categories
-				if len(categories) > 0 {
-					p.Type = categories[0]
-				} else {
-					// No recognised content folders — use "Other" (matches VaM Hub taxonomy).
-					// "Unknown" is reserved for corrupt packages that could not be parsed.
-					p.Type = "Other"
-				}
-
-				p.Tags = meta.Tags
-				p.HasThumbnail = len(thumbBytes) > 0
-			} else {
-				p.Type = "Unknown"
-				p.IsCorrupt = true
-			}
-
-			// Fix empty fields from filename
-			ensureMetaFromFilename(&p)
-
-			// Normalize Tags
-			var normalizedTags []string
-			tagMu.Lock()
-			for _, t := range p.Tags {
-				lowerT := strings.ToLower(t)
-				normalizedTags = append(normalizedTags, lowerT)
-				tagSet[lowerT] = true
-			}
-			tagMu.Unlock()
-			p.Tags = normalizedTags
-
-			// TODO: Status Logic (Duplicate, Obsolete) - Requires global view?
-			// Manager.resolveDuplicates processed the WHOLE list *after* scan in GetPackages?
-			// Wait, ScanAndAnalyze streams individual packages.
-			// It does NOT return the full list.
-			// The Caller (App) accumulated them and then presumably called resolveDuplicates?
-			// Checking `pkg/manager/manager.go` around line 250...
-			// `resolveDuplicates` is a helper method.
-			// `App` calls `ScanAndAnalyze`.
-			// `App` in `GetFilters` used it.
-
-			// Wait, `resolveDuplicates` was NOT called inside `ScanAndAnalyze` in Manager.
-			// The UI/Frontend likely handled it or `App.go`?
-			// I need to check `App.go` or usage of `resolveDuplicates`.
-			// Searching checks... `Manager.resolveDuplicates` is unexported?
-			// If it's unexported and not called in `ScanAndAnalyze`, who calls it?
-			// Maybe `GetPackages`? (Which I might have missed or it was removed/renamed?)
-			// Ah, I see `checkDependencies` and `resolveDuplicates` in `manager.go`.
-			// Are they used?
-
-			// If the Service is responsible for "Status Logic", it should likely be a post-processing step
-			// or done on the fly if state is maintained.
-			// For now, implementing the pure Scan logic.
-
-			cbMu.Lock()
-			current := processed + 1
-			processed = current
-
+	orc := &scanOrchestrator{
+		thumbCache: s.thumbCache,
+		highCh:     make(chan string, 512),
+		bumpPaths:  make(chan []string, 64),
+		onDiscovered: func(p models.VarPackage) {},
+		onScanned: func(p models.VarPackage) {
 			if onPackage != nil {
 				onPackage(p)
 			}
-			if onProgress != nil {
-				if current%10 == 0 || current == total {
-					onProgress(current, total)
-				}
+		},
+		onAnalysisDone: func(_ []PackageAnalysis) {},
+		onStage: func(sp ScanStageProgress) {
+			if onProgress != nil && sp.Stage == StageScanning {
+				onProgress(sp.Current, sp.Total)
 			}
-			cbMu.Unlock()
-
-		}(pkg)
+		},
 	}
 
-	wg.Wait()
-	return nil
+	// Register as active scan so priority bumps can reach it.
+	s.active.mu.Lock()
+	s.active.orchestrator = orc
+	s.active.mu.Unlock()
+	defer func() {
+		s.active.mu.Lock()
+		s.active.orchestrator = nil
+		s.active.mu.Unlock()
+	}()
+
+	return orc.runThreePhase(ctx, rawPkgs)
 }
+
+// ScanFull is the three-phase scan entry point.
+func (s *defaultLibraryService) ScanFull(
+	ctx context.Context,
+	rootPath string,
+	onDiscovered func(models.VarPackage),
+	onScanned func(models.VarPackage),
+	onAnalysisDone func([]PackageAnalysis),
+	onStage func(ScanStageProgress),
+) error {
+	rawPkgs, err := s.scanner.ScanForPackages(rootPath)
+	if err != nil {
+		return err
+	}
+
+	orc := &scanOrchestrator{
+		thumbCache:     s.thumbCache,
+		highCh:         make(chan string, 512),
+		bumpPaths:      make(chan []string, 64),
+		onDiscovered:   onDiscovered,
+		onScanned:      onScanned,
+		onAnalysisDone: onAnalysisDone,
+		onStage:        onStage,
+	}
+
+	s.active.mu.Lock()
+	s.active.orchestrator = orc
+	s.active.mu.Unlock()
+	defer func() {
+		s.active.mu.Lock()
+		s.active.orchestrator = nil
+		s.active.mu.Unlock()
+	}()
+
+	return orc.runThreePhase(ctx, rawPkgs)
+}
+
+// Prioritize bumps the given paths to the front of the Hard Pass queue.
+// Safe to call at any time; no-op if no scan is running.
+func (s *defaultLibraryService) Prioritize(paths []string) {
+	s.active.mu.Lock()
+	orc := s.active.orchestrator
+	s.active.mu.Unlock()
+	if orc == nil || len(paths) == 0 {
+		return
+	}
+	select {
+	case orc.bumpPaths <- paths:
+	default:
+		// Channel full — drop; the package will be scanned in normal order.
+	}
+}
+
+// SetCurrentPage is a convenience wrapper that bumps the paths for the current page.
+func (s *defaultLibraryService) SetCurrentPage(paths []string) {
+	s.Prioritize(paths)
+}
+
+// ClearThumbnailCache removes all cached thumbnails.
+func (s *defaultLibraryService) ClearThumbnailCache() error {
+	if s.thumbCache == nil {
+		return nil
+	}
+	return s.thumbCache.Clear()
+}
+
+// ThumbnailCacheSize returns the total byte size of the thumbnail cache.
+func (s *defaultLibraryService) ThumbnailCacheSize() (int64, error) {
+	if s.thumbCache == nil {
+		return 0, nil
+	}
+	return s.thumbCache.Size()
+}
+
+// ── Category helpers (unchanged) ─────────────────────────────────────────────
 
 func sortCategories(categories []string) {
 	sort.Slice(categories, func(i, j int) bool {
@@ -157,7 +152,7 @@ func sortCategories(categories []string) {
 				return 3
 			case "Morph":
 				return 4
-			case "Plugin": // was "Script" — renamed to match VaM Hub taxonomy
+			case "Plugin":
 				return 5
 			case "Scene":
 				return 6
@@ -223,3 +218,10 @@ func ensureMetaFromFilename(p *models.VarPackage) {
 		}
 	}
 }
+
+// ── Thumbnail cache field injected into the service ───────────────────────────
+// (defined here to co-locate with scan logic; accessed from library.go)
+
+// defaultLibraryService extension — thumb cache and active scan state.
+// These fields are added to the struct in library.go.
+var _ = cache.ThumbnailCache{} // import guard

--- a/pkg/services/library/scan_orchestrator.go
+++ b/pkg/services/library/scan_orchestrator.go
@@ -1,0 +1,311 @@
+package library
+
+import (
+	"context"
+	"os"
+	"strings"
+	"sync"
+	"time"
+	"yavam/pkg/cache"
+	"yavam/pkg/models"
+	"yavam/pkg/parser"
+)
+
+// ScanStage identifies which phase of the three-phase scan is active.
+type ScanStage string
+
+const (
+	StageDiscovery ScanStage = "discovery"
+	StageScanning  ScanStage = "scanning"
+	StageAnalyzing ScanStage = "analyzing"
+)
+
+// ScanStageProgress is emitted via onStage on every meaningful progress tick.
+type ScanStageProgress struct {
+	Stage   ScanStage `json:"stage"`
+	Current int       `json:"current"`
+	Total   int       `json:"total"`
+	Done    bool      `json:"done"`
+}
+
+// scanOrchestrator runs the three-phase scan for a single library path.
+type scanOrchestrator struct {
+	thumbCache *cache.ThumbnailCache
+
+	// Priority queue for the Hard Pass.
+	highCh      chan string
+	normalQueue []string
+	pendingMap  map[string]bool
+	normalMu    sync.Mutex
+	bumpPaths   chan []string
+
+	// Callbacks
+	onDiscovered   func(models.VarPackage)
+	onScanned      func(models.VarPackage)
+	onAnalysisDone func([]PackageAnalysis) // BATCH — called once after all analysis is complete
+	onStage        func(ScanStageProgress)
+}
+
+// runThreePhase executes all three phases sequentially and blocks until completion.
+func (o *scanOrchestrator) runThreePhase(ctx context.Context, rawPkgs []models.VarPackage) error {
+	total := len(rawPkgs)
+
+	// ── Phase 1: LIGHT PASS ───────────────────────────────────────────────────
+	// No zip opens — emit skeleton entries immediately.
+	o.onStage(ScanStageProgress{Stage: StageDiscovery, Current: 0, Total: total})
+
+	discovered := make([]models.VarPackage, 0, total)
+	for i, p := range rawPkgs {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+		ensureMetaFromFilename(&p)
+		discovered = append(discovered, p)
+		o.onDiscovered(p)
+
+		if i%50 == 0 || i == total-1 {
+			o.onStage(ScanStageProgress{Stage: StageDiscovery, Current: i + 1, Total: total})
+		}
+	}
+	o.onStage(ScanStageProgress{Stage: StageDiscovery, Current: total, Total: total, Done: true})
+
+	// ── Phase 2: HARD PASS ────────────────────────────────────────────────────
+	// Open each zip to extract full metadata.
+	// Thumbnails are written to the disk cache but NOT embedded in the event payload.
+	// The frontend lazy-loads thumbnails on demand via GetPackageThumbnail(),
+	// which reads from the cache — preventing all N thumbnails from living in
+	// React state simultaneously.
+	o.onStage(ScanStageProgress{Stage: StageScanning, Current: 0, Total: total})
+
+	o.normalMu.Lock()
+	o.normalQueue = make([]string, 0, total)
+	o.pendingMap = make(map[string]bool, total)
+	for _, p := range discovered {
+		o.normalQueue = append(o.normalQueue, p.FilePath)
+		o.pendingMap[p.FilePath] = true
+	}
+	o.normalMu.Unlock()
+
+	byPath := make(map[string]models.VarPackage, total)
+	for _, p := range discovered {
+		byPath[p.FilePath] = p
+	}
+
+	const workers = 8 // reduced to keep memory pressure lower
+	sem := make(chan struct{}, workers)
+	var wg sync.WaitGroup
+	var scannedMu sync.Mutex
+	scannedPkgs := make([]models.VarPackage, 0, total)
+	scannedCount := 0
+
+	bumpDone := make(chan struct{})
+	go func() {
+		defer close(bumpDone)
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case paths, ok := <-o.bumpPaths:
+				if !ok {
+					return
+				}
+				o.prepend(paths)
+			}
+		}
+	}()
+
+	for {
+		select {
+		case <-ctx.Done():
+			wg.Wait()
+			return ctx.Err()
+		default:
+		}
+
+		path := o.nextPath()
+		if path == "" {
+			break
+		}
+
+		wg.Add(1)
+		sem <- struct{}{}
+		go func(filePath string) {
+			defer wg.Done()
+			defer func() { <-sem }()
+
+			select {
+			case <-ctx.Done():
+				return
+			default:
+			}
+
+			base := byPath[filePath]
+
+			// Check thumbnail cache — if hit, we know there IS a thumbnail but we
+			// do NOT embed it in the emitted package. The frontend will request it
+			// lazily via GetPackageThumbnail → cache hit → fast disk read, not a zip open.
+			hasThumbnail := false
+			if o.thumbCache != nil {
+				info, err := os.Stat(filePath)
+				if err == nil {
+					if _, ok := o.thumbCache.Get(filePath, info.ModTime(), info.Size()); ok {
+						hasThumbnail = true
+					}
+				}
+			}
+
+			meta, freshThumb, categories, err := parser.ParseVarMetadata(filePath)
+			if err == nil {
+				// Preserve filename-inferred Creator and PackageName if the zip's meta.json is missing them.
+				if meta.Creator == "" {
+					meta.Creator = base.Meta.Creator
+				}
+				if meta.PackageName == "" {
+					meta.PackageName = base.Meta.PackageName
+				}
+				if meta.Version == "" && base.Meta.Version != "" {
+					meta.Version = base.Meta.Version
+				}
+				base.Meta = meta
+
+				sortCategories(categories)
+				base.Categories = categories
+				if len(categories) > 0 {
+					base.Type = categories[0]
+				} else {
+					base.Type = "Other"
+				}
+
+				// Normalize tags
+				normTags := make([]string, 0, len(meta.Tags))
+				for _, t := range meta.Tags {
+					normTags = append(normTags, strings.ToLower(t))
+				}
+				base.Tags = normTags
+
+				// Cache fresh thumbnail if we got one (and didn't already have a cache hit).
+				if !hasThumbnail && len(freshThumb) > 0 {
+					hasThumbnail = true
+					if o.thumbCache != nil {
+						info, err2 := os.Stat(filePath)
+						if err2 == nil {
+							_ = o.thumbCache.Set(filePath, info.ModTime(), info.Size(), freshThumb)
+						}
+					}
+				}
+
+				// Only set HasThumbnail flag — do NOT embed base64 in the event.
+				// Embedding all thumbnails bloats Wails event traffic and forces all
+				// thumbnail bytes to live in React state simultaneously (RAM explosion).
+				base.HasThumbnail = hasThumbnail
+				base.ThumbnailBase64 = "" // always empty in events
+			} else {
+				base.Type = "Other"
+				base.IsCorrupt = true
+			}
+
+			scannedMu.Lock()
+			scannedCount++
+			current := scannedCount
+			scannedPkgs = append(scannedPkgs, base)
+			scannedMu.Unlock()
+
+			o.onScanned(base)
+			if current%25 == 0 || current == total {
+				o.onStage(ScanStageProgress{Stage: StageScanning, Current: current, Total: total})
+			}
+		}(path)
+
+		time.Sleep(time.Microsecond)
+	}
+
+	wg.Wait()
+	close(o.bumpPaths)
+	<-bumpDone
+
+	o.onStage(ScanStageProgress{Stage: StageScanning, Current: total, Total: total, Done: true})
+
+	// ── Phase 3: LINK PASS ────────────────────────────────────────────────────
+	// Dependency resolution, duplicate detection, orphan analysis.
+	// Results are delivered as a SINGLE BATCH to avoid N×O(N) React state updates.
+	//
+	// Previously: N individual "package:analyzed" events → N calls to setPackages(prev.map())
+	//             = O(N²) work for 5,000 packages = 25 million array operations → freeze
+	// Now:        1 "scan:analysis:complete" event → 1 call to setPackages(prev.map())
+	//             = O(N) work regardless of library size.
+	o.onStage(ScanStageProgress{Stage: StageAnalyzing, Current: 0, Total: total})
+
+	local := NewLocalResolver(scannedPkgs)
+	analyses := LinkPass(scannedPkgs, local)
+
+	o.onStage(ScanStageProgress{Stage: StageAnalyzing, Current: total, Total: total, Done: true})
+	o.onAnalysisDone(analyses) // single batch callback
+
+	return nil
+}
+
+// nextPath returns the next path to scan, preferring highCh over normalQueue.
+func (o *scanOrchestrator) nextPath() string {
+	for {
+		select {
+		case p := <-o.highCh:
+			o.normalMu.Lock()
+			if o.pendingMap[p] {
+				delete(o.pendingMap, p)
+				o.normalMu.Unlock()
+				return p
+			}
+			o.normalMu.Unlock()
+			// Already dispatched; ignore and loop.
+		default:
+			o.normalMu.Lock()
+			if len(o.normalQueue) == 0 {
+				o.normalMu.Unlock()
+				return ""
+			}
+			p := o.normalQueue[0]
+			o.normalQueue = o.normalQueue[1:]
+			if o.pendingMap[p] {
+				delete(o.pendingMap, p)
+				o.normalMu.Unlock()
+				return p
+			}
+			o.normalMu.Unlock()
+			// Should be rare, but loop just in case.
+		}
+	}
+}
+
+// prepend moves the given paths to the front of the high-priority channel.
+func (o *scanOrchestrator) prepend(paths []string) {
+	set := make(map[string]bool, len(paths))
+	var toPush []string
+
+	o.normalMu.Lock()
+	for _, p := range paths {
+		if o.pendingMap[p] {
+			toPush = append(toPush, p)
+			set[p] = true
+		}
+	}
+
+	if len(toPush) > 0 {
+		filtered := o.normalQueue[:0]
+		for _, p := range o.normalQueue {
+			if !set[p] {
+				filtered = append(filtered, p)
+			}
+		}
+		o.normalQueue = filtered
+	}
+	o.normalMu.Unlock()
+
+	for _, p := range toPush {
+		select {
+		case o.highCh <- p:
+		default:
+		}
+	}
+}

--- a/pkg/services/library/service.go
+++ b/pkg/services/library/service.go
@@ -5,13 +5,47 @@ import (
 	"yavam/pkg/models"
 )
 
-// LibraryService defines the core operations for VAM Package Management
+// LibraryService defines the core operations for VAM Package Management.
 type LibraryService interface {
-	// Indexing & Read Operations
+	// ── Scan ──────────────────────────────────────────────────────────────────
+
+	// Scan is the legacy single-callback scan entry point (preserved for backward compatibility).
 	Scan(ctx context.Context, libraryPath string, onPackage func(models.VarPackage), onProgress func(int, int)) error
+
+	// ScanFull is the three-phase scan entry point.
+	// onDiscovered    fires during the Light Pass (skeleton data, no zip open).
+	// onScanned       fires during the Hard Pass (full metadata; NO thumbnail bytes in payload).
+	// onAnalysisDone  fires ONCE after the Link Pass with ALL results as a batch.
+	//                 This avoids N×O(N) React state updates for large libraries.
+	// onStage         fires on every meaningful progress tick across all three phases.
+	ScanFull(
+		ctx context.Context,
+		libraryPath string,
+		onDiscovered func(models.VarPackage),
+		onScanned func(models.VarPackage),
+		onAnalysisDone func([]PackageAnalysis),
+		onStage func(ScanStageProgress),
+	) error
+
+	// Prioritize bumps the given package paths to the front of the Hard Pass queue.
+	// Safe to call at any time; no-op if the Hard Pass is not currently running.
+	Prioritize(paths []string)
+
+	// SetCurrentPage is a convenience wrapper for Prioritize with page-change semantics.
+	SetCurrentPage(paths []string)
+
+	// ── Thumbnail Cache ───────────────────────────────────────────────────────
+
+	ClearThumbnailCache() error
+	ThumbnailCacheSize() (int64, error)
+
+	// ── Read Operations ───────────────────────────────────────────────────────
+
 	GetCounts(libraries []string) map[string]int
 	GetPackageContents(pkgPath string) ([]models.PackageContent, error)
 	GetThumbnail(pkgPath string) ([]byte, error)
+
+	// ── Write Operations ──────────────────────────────────────────────────────
 
 	Install(files []string, targetLib string, overwrite bool, onProgress func(int, int, string)) ([]string, error)
 	CheckCollisions(filePaths []string, destLibPath string) ([]string, error)

--- a/wails.json
+++ b/wails.json
@@ -12,7 +12,7 @@
     "info": {
         "companyName": "FivelSystems",
         "productName": "YAVAM",
-        "productVersion": "1.3.17-dev",
+        "productVersion": "1.3.17",
         "copyright": "Copyright \u00a9 2026",
         "comments": "Manage your Virt-A-Mate addon packages"
     },

--- a/wails.json
+++ b/wails.json
@@ -12,7 +12,7 @@
     "info": {
         "companyName": "FivelSystems",
         "productName": "YAVAM",
-        "productVersion": "1.3.16",
+        "productVersion": "1.3.17-dev",
         "copyright": "Copyright \u00a9 2026",
         "comments": "Manage your Virt-A-Mate addon packages"
     },


### PR DESCRIPTION
### Fixed
- **Library Switching**: Clean stop between library selections now works properly even in web clients.
- **Library Switching**: Packages from previous libraries will no longer appear after switching libraries from an unfinished scan process.
- **Privacy Settings**: Resolved a race condition where privacy mode and blur settings were not applying properly upon application launch.
- **Network Settings**: Improved server initialization logic. The "Start Server" button now correctly triggers the server process independently instead of incorrectly manipulating the "Run on Startup" preference toggle.
### Added
- **Scan Optimization (Issue #34)**: Replaced the monolithic up-front zip scan with a three-phase pipeline:
  - **Light Pass**: Filesystem walk only — package cards appear as animated skeletons within seconds of opening a library. No `.var` files are opened in this phase.
  - **Hard Pass**: Prioritized zip scan — packages on the current page are always processed first. Navigating to a new page or clicking an unscanned card immediately reprioritizes that work in the queue. Thumbnails appear as each package finishes.
  - **Link Pass**: Dependency resolution, duplicate detection, and orphan analysis run after all packages are scanned. Results (missing deps, obsolete, duplicate flags) are streamed back per-package via a `package:analyzed` event.
- **Thumbnail Cache**: Package cover images are now cached to `%AppData%/YAVAM/thumbnails/`. On subsequent library opens, thumbnails are served from cache, completely skipping the zip open for that step. Cache keys include file modification time and size, so updated packages invalidate automatically.
- **Stacked Progress Bar**: The existing single progress bar is replaced with three stacked strips — one per scan phase (blue = Discovering, amber = Scanning, green = Analysing). Each strip shows its own package count and fills independently.
- **Settings — Thumbnail Cache**: New "Thumbnail Cache" section in Application settings shows current cache size and provides a "Clear Cache" button.
- **Extensible `DependencyResolver` interface** (`pkg/services/library/dependency_resolver.go`): The Link Pass accepts a slice of resolvers tried in order. `LocalResolver` (current library) is the default. Future `MultiLibraryResolver` and `OnlineResolver` implementations can be plugged in without changing the scan orchestrator.

### Changed
- **Search Bar**: Search no longer filters in real-time while typing. Results are applied on Enter (desktop) or the search button (mobile). This prevents the package grid from jumping mid-scan as the user types. Escape clears the search.
- **Backend Analysis**: Dependency/duplicate/orphan analysis (`analyzePackages`) moved from the frontend to the Go backend (`LinkPass` in `pkg/services/library/analysis.go`). The frontend now listens for `package:analyzed` events instead of running a full graph traversal in the browser.
- **Scan Events**: New `package:discovered` (Light Pass) and `package:analyzed` (Link Pass) events join the existing `package:scanned`. The `scan:progress` event is replaced by `scan:stage` which carries the active phase name, current count, total, and done flag.